### PR TITLE
fix(handlers)!: stop leaking dependency errors on /healthcheck

### DIFF
--- a/.claude/skills/write-go-code/SKILL.md
+++ b/.claude/skills/write-go-code/SKILL.md
@@ -683,6 +683,15 @@ or raw `error.Error()` output in HTTP responses. Map to a generic status text:
 http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 ```
 
+This rule applies to **structured response bodies** too, not just `http.Error` shortcuts. A health,
+status, or diagnostic endpoint that returns JSON must not embed `err.Error()` in any field — the
+public shape should carry a binary state (e.g. `"up"` / `"down"`) and at most a stable error _code_,
+never the raw message. Wrapped database errors routinely contain hostnames, ports, or internal
+schema names; one call to `err.Error()` on a downed dependency is enough to leak infrastructure
+topology to an unauthenticated caller. Log or trace the full error instead; return only the shape
+an external client is entitled to see. If operators need richer detail, expose it on a separate,
+auth-gated endpoint — not the public one.
+
 gRPC handlers are internal (service-to-service), so slightly more context in status messages is
 acceptable, but still avoid leaking raw database errors or cryptographic details.
 
@@ -723,9 +732,46 @@ When this service or any Agora service handles key material:
 - **`context.Context` stored in a struct.** Always pass it as a method argument.
 - **New packages without asking.** Always get explicit developer approval before adding to `go.mod`.
 - **Returning raw error details in REST responses.** Always map to a generic HTTP status text.
+  The rule covers structured response fields too: a health/status JSON body must never include
+  `err.Error()` — it leaks infrastructure detail (hostnames, schema names) to unauthenticated callers.
 - **Logging or tracing sensitive material.** Only record identifiers, never key ciphertexts, tokens, or credentials.
 - **String-formatted SQL.** All SQL must use parameterized queries via bun — no `fmt.Sprintf` in query construction.
 - **Validation in handlers instead of services.** Business-rule checks belong in services. Handlers only reject structurally invalid input (e.g., unparseable UUID).
+- **Multiple `time.Now()` calls in one operation.** When an operation writes or returns several
+  timestamps that should share the same instant (created-at + expires-at, start + deadline),
+  capture `now := time.Now()` once and reuse it. Independent calls drift by nanoseconds, break
+  tests that assert exact TTLs, and muddy the semantics of the record.
+
+---
+
+## Time Capture
+
+When an operation derives more than one timestamp from "now" — a created-at plus an expires-at,
+a start plus a deadline, paired audit fields — capture `time.Now()` **once** at the top of the
+operation and reuse the variable:
+
+```go
+// WRONG — two independent wall-clock reads; the deltas between derived
+// timestamps are not exactly the configured TTL.
+repo.Exec(ctx, &dao.InsertRequest{
+    Now:        time.Now(),
+    Expiration: time.Now().Add(cfg.TTL),
+})
+
+// CORRECT — one logical instant, reused.
+now := time.Now()
+repo.Exec(ctx, &dao.InsertRequest{
+    Now:        now,
+    Expiration: now.Add(cfg.TTL),
+})
+```
+
+Two reasons: correctness (the second `time.Now()` is measurably later, so a row's
+`expires_at - created_at` is not exactly the TTL), and testability (a single captured value is
+easier to freeze or assert against than two independent wall-clock reads). The rule extends to any
+pair of values that should share the same "now": audit logs with both `started_at` and `recorded_at`,
+request traces that emit `begin` and `finish` attributes, etc. Only call `time.Now()` multiple
+times when you genuinely want distinct measurements (e.g., computing a duration).
 
 ---
 

--- a/internal/handlers/rest.health.go
+++ b/internal/handlers/rest.health.go
@@ -20,24 +20,21 @@ const (
 )
 
 // RestHealthStatus is the JSON representation of a single dependency's health.
+// The shape is deliberately minimal: /healthcheck is an unauthenticated public
+// endpoint, so it must not expose raw error messages — those routinely include
+// internal hostnames, ports, or schema names that leak infrastructure topology.
+// The underlying error is recorded on the trace span for operators instead.
 type RestHealthStatus struct {
 	// Status is either [RestHealthStatusUp] or [RestHealthStatusDown].
 	Status string `json:"status"`
-	// Err is the error message when Status is [RestHealthStatusDown]; empty otherwise.
-	Err string `json:"err,omitempty"`
 }
 
 // NewRestHealthStatus converts an error into a RestHealthStatus, mapping nil to
-// [RestHealthStatusUp] and any non-nil error to [RestHealthStatusDown].
+// [RestHealthStatusUp] and any non-nil error to [RestHealthStatusDown]. The error
+// itself is intentionally discarded from the public response; see [RestHealthStatus].
 func NewRestHealthStatus(err error) *RestHealthStatus {
-	errMsg := ""
-	if err != nil {
-		errMsg = err.Error()
-	}
-
 	return &RestHealthStatus{
 		Status: lo.Ternary(err == nil, RestHealthStatusUp, RestHealthStatusDown),
-		Err:    errMsg,
 	}
 }
 

--- a/internal/handlers/rest.health_test.go
+++ b/internal/handlers/rest.health_test.go
@@ -24,6 +24,8 @@ func TestRestHealth(t *testing.T) {
 
 		request *http.Request
 
+		skipPostgres bool
+
 		expectStatus   int
 		expectResponse any
 	}{
@@ -39,6 +41,24 @@ func TestRestHealth(t *testing.T) {
 			},
 			expectStatus: http.StatusOK,
 		},
+		{
+			// Omitting postgres from the context makes reportPostgres fail, so the
+			// entry reports status=down. The exact-match assertion on expectResponse
+			// below is the regression guard: it fails if any extra field (notably a
+			// re-introduced "err") leaks into the public response shape.
+			name: "Success/Degraded",
+
+			request: httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/healthcheck", nil),
+
+			skipPostgres: true,
+
+			expectResponse: map[string]any{
+				"client:postgres": map[string]any{
+					"status": handlers.RestHealthStatusDown,
+				},
+			},
+			expectStatus: http.StatusOK,
+		},
 	}
 
 	for _, testCase := range testCases {
@@ -49,8 +69,11 @@ func TestRestHealth(t *testing.T) {
 			w := httptest.NewRecorder()
 
 			rCtx := testCase.request.Context()
-			rCtx, err := postgres.NewContext(rCtx, config.PostgresPresetTest)
-			require.NoError(t, err)
+			if !testCase.skipPostgres {
+				var err error
+				rCtx, err = postgres.NewContext(rCtx, config.PostgresPresetTest)
+				require.NoError(t, err)
+			}
 
 			handler.ServeHTTP(w, testCase.request.WithContext(rCtx))
 

--- a/internal/handlers/rest.health_test.go
+++ b/internal/handlers/rest.health_test.go
@@ -71,6 +71,7 @@ func TestRestHealth(t *testing.T) {
 			rCtx := testCase.request.Context()
 			if !testCase.skipPostgres {
 				var err error
+
 				rCtx, err = postgres.NewContext(rCtx, config.PostgresPresetTest)
 				require.NoError(t, err)
 			}

--- a/internal/services/jwkGen.go
+++ b/internal/services/jwkGen.go
@@ -153,13 +153,15 @@ func (service *JwkGen) Exec(ctx context.Context, request *JwkGenRequest) (*Jwk, 
 			span.AddEvent("key.public.encoded")
 		}
 
+		now := time.Now()
+
 		latestKey, err = service.repositoryInsert.Exec(ctx, &dao.JwkInsertRequest{
 			ID:         kid,
 			PrivateKey: privateKeyEncoded,
 			PublicKey:  publicKeyEncoded,
 			Usage:      request.Usage,
-			Now:        time.Now(),
-			Expiration: time.Now().Add(keyConfig.Key.TTL),
+			Now:        now,
+			Expiration: now.Add(keyConfig.Key.TTL),
 		})
 		if err != nil {
 			return nil, otel.ReportError(span, fmt.Errorf("insert key: %w", err))

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -178,9 +178,10 @@ components:
     healthStatus:
       type: object
       description: |
-        Summary of a server's dependency status. The shape is intentionally minimal
-        so that an unauthenticated caller cannot infer infrastructure details from a
-        degraded dependency; richer diagnostics are recorded on server-side traces.
+        Status of a single dependency entry, as observed by the server. The shape is
+        intentionally minimal so that an unauthenticated caller cannot infer
+        infrastructure details from a degraded dependency; richer diagnostics are
+        recorded on server-side traces.
       required: [status]
       additionalProperties: false
       examples:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -125,7 +125,7 @@ components:
             healthy:
               value: { "client:postgres": { "status": "up" } }
             degraded:
-              value: { "client:postgres": { "status": "down", "err": "Connection to host refused" } }
+              value: { "client:postgres": { "status": "down" } }
 
     jwkList:
       description: A list of public JSON Web Keys.
@@ -177,20 +177,20 @@ components:
   schemas:
     healthStatus:
       type: object
-      description: Summary of a server's dependencies status.
+      description: |
+        Summary of a server's dependency status. The shape is intentionally minimal
+        so that an unauthenticated caller cannot infer infrastructure details from a
+        degraded dependency; richer diagnostics are recorded on server-side traces.
       required: [status]
       additionalProperties: false
       examples:
         - { "status": "up" }
-        - { "status": "down", "err": "Connection to host refused" }
+        - { "status": "down" }
       properties:
         status:
           type: string
           description: Exposes whether the server managed to connect to the dependency.
           enum: [up, down]
-        err:
-          type: string
-          description: The error message returned by the dependency, if any.
 
     jwk:
       type: object

--- a/pkg/js/rest/src/api.ts
+++ b/pkg/js/rest/src/api.ts
@@ -4,8 +4,6 @@ import { handleHttpResponse } from "@a-novel-kit/nodelib-browser/http";
 export type HealthDependency = {
   /** Whether the dependency is reachable. */
   status: "up" | "down";
-  /** Human-readable error message when status is `"down"`. */
-  err?: string;
 };
 
 /**


### PR DESCRIPTION
## Summary

- `/healthcheck` previously surfaced raw `err.Error()` in the `err` field of each dependency's status, leaking internal hostnames, ports, and schema names to any anonymous caller on a degraded dependency. The field is removed; callers get only the binary `up`/`down` signal.
- `JwkGen.Exec` called `time.Now()` twice in the same insert — once for `Now`, again inside `Now.Add(TTL)`. The two reads drifted by nanoseconds, so `expires_at - created_at` was never exactly the configured TTL. Captured once and reused.
- Both patterns are now codified in the `write-go-code` skill so future code lands correctly the first time.

## Layers changed

- **Handlers**: `RestHealthStatus.Err` removed; `NewRestHealthStatus` no longer carries the error string.
- **Services**: `JwkGen.Exec` captures a single `now` for the insert's `Now` and `Expiration`.
- **OpenAPI**: `healthStatus` schema no longer defines `err`; the degraded example is updated.
- **pkg/js**: `HealthDependency.err` removed from the exported TS type.
- **Skills**: `write-go-code` adds a "structured response bodies" paragraph, two "never do" bullets, and a new "Time Capture" section.

## Breaking changes

**Yes** — REST response shape and exported TS type both change:

- `GET /healthcheck` responses no longer include `err` on any dependency entry. Clients that displayed or parsed this field must be updated; only `status` (`"up"` | `"down"`) remains.
- The exported TypeScript type `HealthDependency` drops its optional `err?: string` property.

Rationale: the field was a direct infrastructure-topology leak on an unauthenticated endpoint. Operators can still inspect the underlying error via the trace span.

## Test plan

- [x] `make test-unit` passes locally (105 tests, internal/handlers 91.7% / internal/services 78.8%)
- [ ] `make test-pkg-js` (skipped locally — requires full containerized service; the TS change is a mechanical optional-property removal with no in-repo consumers, CI will exercise it)
- [ ] CI green