### PR TITLE
chore(skills): add monitor-ci, open-pull-request, write-project-docs skills

### DIFF
--- a/.claude/skills/monitor-ci/SKILL.md
+++ b/.claude/skills/monitor-ci/SKILL.md
@@ -142,20 +142,22 @@ determines the fix path.
 **Root cause**: a `.proto` file or Go interface (used by a mock) changed without `make
 generate` being run afterward.
 
-**Fix**:
+**Fix**: the original commit is already pushed, so a new commit is the only option —
+`git-conventions` forbids amending pushed history. The regenerated files land as their
+own follow-up:
 
 ```bash
 make generate
 git status --porcelain
-# Stage the regenerated files into the commit that changed the proto/interface:
 git add internal/models/proto/gen/ internal/handlers/mocks/ internal/services/mocks/
-git commit --amend --no-edit
-git push --force-with-lease
+git commit -m "chore(gen): regenerate Go bindings for <scope>"
+git push
 ```
 
-If the offending commit is not the most recent, use an interactive rebase — but prefer to
-surface the situation to the user first, since rewriting earlier history is unusual and the
-user may want to handle it differently.
+This produces two commits for what would ideally be one (the proto/interface change
+plus its regen), but that is the cost of noticing after push. The "generated files
+belong in the same commit" guidance in `git-conventions` is a structure preference;
+the "never amend a pushed commit" rule is categorical and wins here.
 
 ### 2.2 `lint-go` / `lint-proto` / `lint-node` failure
 
@@ -173,9 +175,11 @@ git commit -m "fix(<scope>): resolve lint findings"
 git push
 ```
 
-When the lint fix is a trivial mechanical change in the same commit's scope, prefer
-`--amend` into the original commit rather than adding a noisy `fix(lint): ...` follow-up.
-When the fix is more invasive, use a new commit with a `refactor` or `fix` type.
+Use a `fix(<scope>): resolve lint findings` commit for trivial mechanical changes and a
+`refactor` or `fix` commit for more invasive rewrites. A noisy `fix(lint): ...` follow-up
+on a pushed branch is still better than an amend — `git-conventions` forbids amending
+pushed commits unconditionally, and the lint-fix commit can be squashed or absorbed by
+the PR author at merge time if the branch uses squash-merge.
 
 ### 2.3 `test` (Go unit) failure
 

--- a/.claude/skills/monitor-ci/SKILL.md
+++ b/.claude/skills/monitor-ci/SKILL.md
@@ -29,7 +29,7 @@ The `main` workflow runs on every push to any branch. Jobs and their fix targets
 | `generated-go`                                   | `go generate ./...` is up to date          | `make generate`                          | Forgot to run `make generate` after proto/interface |
 | `lint-go`                                        | `golangci-lint run` clean                  | `make lint-go`                           | New Go code violates style or has a bug             |
 | `lint-proto`                                     | `buf lint` clean                           | `make lint-proto`                        | Proto file violates buf style                       |
-| `lint-node`                                      | `pnpm lint:ci` clean                       | `make lint-node`                         | JS/TS code violates eslint/prettier                 |
+| `lint-node`                                      | `pnpm lint:ci` clean                       | `pnpm lint:ci`                           | JS/TS code violates eslint/prettier                 |
 | `test`                                           | Go unit tests in `/internal`               | `make test-unit`                         | Broken Go code or test                              |
 | `test-pkg`                                       | Go integration tests in `/pkg/go`          | `make test-pkg`                          | gRPC contract mismatch OR flake                     |
 | `test-pkg-js`                                    | JS integration tests in `/pkg/js`          | `make test-pkg-js`                       | REST contract mismatch OR flake                     |
@@ -43,8 +43,11 @@ The `main` workflow runs on every push to any branch. Jobs and their fix targets
 | `build-js`                                       | `pnpm build:rest` for pkg/js               | `pnpm -C pkg/js build:rest`              | TS compile error or broken export                   |
 | `report-grc` / `report-codecov` / `publish-docs` | Post-success reporting (master only)       | (none)                                   | Rarely actionable; usually transient                |
 
-`test` blocks all `build-*` jobs. If `test` fails, every build job is also cancelled — do
-not try to fix them in isolation; fix `test` first.
+`test` blocks most application `build-*` jobs (`build-grpc`, `build-rest`,
+`build-standalone-*`, `build-job-rotate-keys`). When `test` fails those downstream jobs
+are cancelled — fix `test` first before looking at them. However, `build-database` does
+**not** depend on `test`, and `build-migrations` depends only on `build-database`, so
+failures in those two surface independently and need their own diagnosis.
 
 ---
 
@@ -365,7 +368,7 @@ confidence-building.
 | `generated-go` | `make generate` + follow-up commit |
 | `lint-go`      | `make lint-go`                     |
 | `lint-proto`   | `make lint-proto`                  |
-| `lint-node`    | `make lint-node`                   |
+| `lint-node`    | `pnpm lint:ci`                     |
 | `test`         | `make test-unit`                   |
 | `test-pkg`     | `make test-pkg`                    |
 | `test-pkg-js`  | `make test-pkg-js`                 |

--- a/.claude/skills/monitor-ci/SKILL.md
+++ b/.claude/skills/monitor-ci/SKILL.md
@@ -24,25 +24,25 @@ the budget runs out, stop and escalate.
 
 The `main` workflow runs on every push to any branch. Jobs and their fix targets:
 
-| CI Job                                           | What it checks                             | Local equivalent                         | Typical failure                                     |
-| ------------------------------------------------ | ------------------------------------------ | ---------------------------------------- | --------------------------------------------------- |
-| `generated-go`                                   | `go generate ./...` is up to date          | `make generate`                          | Forgot to run `make generate` after proto/interface |
-| `lint-go`                                        | `golangci-lint run` clean                  | `make lint-go`                           | New Go code violates style or has a bug             |
-| `lint-proto`                                     | `buf lint` clean                           | `make lint-proto`                        | Proto file violates buf style                       |
-| `lint-node`                                      | `pnpm lint:ci` clean                       | `pnpm lint:ci`                           | JS/TS code violates eslint/prettier                 |
-| `test`                                           | Go unit tests in `/internal`               | `make test-unit`                         | Broken Go code or test                              |
-| `test-pkg`                                       | Go integration tests in `/pkg/go`          | `make test-pkg`                          | gRPC contract mismatch OR flake                     |
-| `test-pkg-js`                                    | JS integration tests in `/pkg/js`          | `make test-pkg-js`                       | REST contract mismatch OR flake                     |
-| `build-database`                                 | Docker build for Postgres image            | (no direct make target; read Dockerfile) | Dockerfile error, bad init script                   |
-| `build-migrations`                               | Docker build for migrations job            | (none)                                   | Migration file issue                                |
-| `build-job-rotate-keys`                          | Docker build for rotate-keys job           | (none)                                   | Go build error in cmd/rotatekeys                    |
-| `build-grpc`                                     | Docker build for gRPC service image        | (none)                                   | Go build error                                      |
-| `build-standalone-grpc`                          | Docker build for standalone gRPC dev image | (none)                                   | Go build error                                      |
-| `build-rest`                                     | Docker build for REST service image        | (none)                                   | Go build error                                      |
-| `build-standalone-rest`                          | Docker build for standalone REST dev image | (none)                                   | Go build error                                      |
-| `build-js`                                       | `pnpm build:rest` for pkg/js               | `pnpm -C pkg/js build:rest`              | TS compile error or broken export                   |
-| `report-grc` / `publish-docs`                    | Post-success reporting, **master only**    | (none)                                   | Rarely actionable; usually transient                |
-| `report-codecov`                                 | Coverage upload, runs on **every branch**  | (none)                                   | Upload failure can still mark the run failed in PR checks; usually transient |
+| CI Job                        | What it checks                             | Local equivalent                         | Typical failure                                                              |
+| ----------------------------- | ------------------------------------------ | ---------------------------------------- | ---------------------------------------------------------------------------- |
+| `generated-go`                | `go generate ./...` is up to date          | `make generate`                          | Forgot to run `make generate` after proto/interface                          |
+| `lint-go`                     | `golangci-lint run` clean                  | `make lint-go`                           | New Go code violates style or has a bug                                      |
+| `lint-proto`                  | `buf lint` clean                           | `make lint-proto`                        | Proto file violates buf style                                                |
+| `lint-node`                   | `pnpm lint:ci` clean                       | `pnpm lint:ci`                           | JS/TS code violates eslint/prettier                                          |
+| `test`                        | Go unit tests in `/internal`               | `make test-unit`                         | Broken Go code or test                                                       |
+| `test-pkg`                    | Go integration tests in `/pkg/go`          | `make test-pkg`                          | gRPC contract mismatch OR flake                                              |
+| `test-pkg-js`                 | JS integration tests in `/pkg/js`          | `make test-pkg-js`                       | REST contract mismatch OR flake                                              |
+| `build-database`              | Docker build for Postgres image            | (no direct make target; read Dockerfile) | Dockerfile error, bad init script                                            |
+| `build-migrations`            | Docker build for migrations job            | (none)                                   | Migration file issue                                                         |
+| `build-job-rotate-keys`       | Docker build for rotate-keys job           | (none)                                   | Go build error in cmd/rotatekeys                                             |
+| `build-grpc`                  | Docker build for gRPC service image        | (none)                                   | Go build error                                                               |
+| `build-standalone-grpc`       | Docker build for standalone gRPC dev image | (none)                                   | Go build error                                                               |
+| `build-rest`                  | Docker build for REST service image        | (none)                                   | Go build error                                                               |
+| `build-standalone-rest`       | Docker build for standalone REST dev image | (none)                                   | Go build error                                                               |
+| `build-js`                    | `pnpm build:rest` for pkg/js               | `pnpm -C pkg/js build:rest`              | TS compile error or broken export                                            |
+| `report-grc` / `publish-docs` | Post-success reporting, **master only**    | (none)                                   | Rarely actionable; usually transient                                         |
+| `report-codecov`              | Coverage upload, runs on **every branch**  | (none)                                   | Upload failure can still mark the run failed in PR checks; usually transient |
 
 `test` blocks most application `build-*` jobs (`build-grpc`, `build-rest`,
 `build-standalone-*`, `build-job-rotate-keys`). When `test` fails those downstream jobs

--- a/.claude/skills/monitor-ci/SKILL.md
+++ b/.claude/skills/monitor-ci/SKILL.md
@@ -360,14 +360,14 @@ confidence-building.
 | Rerun failed jobs only (flake retry)  | `gh run rerun <run-id> --failed`                                                    |
 | Wait for in-progress run              | Bash `sleep 90` with `run_in_background=true`, then re-check                        |
 
-| CI Job         | Local fix target            |
-| -------------- | --------------------------- |
+| CI Job         | Local fix target                   |
+| -------------- | ---------------------------------- |
 | `generated-go` | `make generate` + follow-up commit |
-| `lint-go`      | `make lint-go`              |
-| `lint-proto`   | `make lint-proto`           |
-| `lint-node`    | `make lint-node`            |
-| `test`         | `make test-unit`            |
-| `test-pkg`     | `make test-pkg`             |
-| `test-pkg-js`  | `make test-pkg-js`          |
-| `build-js`     | `pnpm -C pkg/js build:rest` |
-| `build-*` (Go) | `go build ./...`            |
+| `lint-go`      | `make lint-go`                     |
+| `lint-proto`   | `make lint-proto`                  |
+| `lint-node`    | `make lint-node`                   |
+| `test`         | `make test-unit`                   |
+| `test-pkg`     | `make test-pkg`                    |
+| `test-pkg-js`  | `make test-pkg-js`                 |
+| `build-js`     | `pnpm -C pkg/js build:rest`        |
+| `build-*` (Go) | `go build ./...`                   |

--- a/.claude/skills/monitor-ci/SKILL.md
+++ b/.claude/skills/monitor-ci/SKILL.md
@@ -356,7 +356,7 @@ confidence-building.
 | Situation                             | Command                                                                             |
 | ------------------------------------- | ----------------------------------------------------------------------------------- |
 | Overall status (PR open)              | `gh pr checks --watch=false`                                                        |
-| Overall status (no PR)                | `gh run list --branch <br> --limit 1 --json databaseId,status,conclusion,name`      |
+| Overall status (no PR)                | `gh run list --branch <branch> --limit 1 --json databaseId,status,conclusion,name`  |
 | List failing jobs in a run            | `gh run view <run-id> --json jobs --jq '.jobs[] \| select(.conclusion=="failure")'` |
 | Read only failed-step logs of one job | `gh run view <run-id> --log-failed --job <job-id>`                                  |
 | Narrow noisy logs                     | `... \| tail -n 200` or `... \| grep -E "FAIL\|Error" \| head -n 50`                |

--- a/.claude/skills/monitor-ci/SKILL.md
+++ b/.claude/skills/monitor-ci/SKILL.md
@@ -1,0 +1,364 @@
+---
+name: monitor-ci
+description: >
+  Monitor GitHub Actions CI runs on a pushed branch or open PR, classify failures, and apply
+  autonomous fixes where safe. Use this skill whenever waiting on CI, investigating a failing
+  check, deciding whether a failure is real or flaky, or iterating a branch toward green.
+  Covers the CI job map for Agora backend services and the retry/fix loop. Pairs with
+  open-pull-request (which hands off here after a push) and git-conventions (for fix commits).
+---
+
+# Monitor CI
+
+This skill governs how Claude watches CI after pushing to a branch, classifies failures, and
+applies fixes. CI is the final gate before review — failures must be resolved, not ignored.
+But CI is also long-running and noisy, and unstructured polling burns context. This skill
+codifies which commands to run, how often, and how to act on each failure type.
+
+The loop is: **observe → classify → fix → re-push → re-observe**, with a retry budget. When
+the budget runs out, stop and escalate.
+
+---
+
+## CI Job Map (this repo)
+
+The `main` workflow runs on every push to any branch. Jobs and their fix targets:
+
+| CI Job                                           | What it checks                             | Local equivalent                         | Typical failure                                     |
+| ------------------------------------------------ | ------------------------------------------ | ---------------------------------------- | --------------------------------------------------- |
+| `generated-go`                                   | `go generate ./...` is up to date          | `make generate`                          | Forgot to run `make generate` after proto/interface |
+| `lint-go`                                        | `golangci-lint run` clean                  | `make lint-go`                           | New Go code violates style or has a bug             |
+| `lint-proto`                                     | `buf lint` clean                           | `make lint-proto`                        | Proto file violates buf style                       |
+| `lint-node`                                      | `pnpm lint:ci` clean                       | `make lint-node`                         | JS/TS code violates eslint/prettier                 |
+| `test`                                           | Go unit tests in `/internal`               | `make test-unit`                         | Broken Go code or test                              |
+| `test-pkg`                                       | Go integration tests in `/pkg/go`          | `make test-pkg`                          | gRPC contract mismatch OR flake                     |
+| `test-pkg-js`                                    | JS integration tests in `/pkg/js`          | `make test-pkg-js`                       | REST contract mismatch OR flake                     |
+| `build-database`                                 | Docker build for Postgres image            | (no direct make target; read Dockerfile) | Dockerfile error, bad init script                   |
+| `build-migrations`                               | Docker build for migrations job            | (none)                                   | Migration file issue                                |
+| `build-job-rotate-keys`                          | Docker build for rotate-keys job           | (none)                                   | Go build error in cmd/rotatekeys                    |
+| `build-grpc`                                     | Docker build for gRPC service image        | (none)                                   | Go build error                                      |
+| `build-standalone-grpc`                          | Docker build for standalone gRPC dev image | (none)                                   | Go build error                                      |
+| `build-rest`                                     | Docker build for REST service image        | (none)                                   | Go build error                                      |
+| `build-standalone-rest`                          | Docker build for standalone REST dev image | (none)                                   | Go build error                                      |
+| `build-js`                                       | `pnpm build:rest` for pkg/js               | `pnpm -C pkg/js build:rest`              | TS compile error or broken export                   |
+| `report-grc` / `report-codecov` / `publish-docs` | Post-success reporting (master only)       | (none)                                   | Rarely actionable; usually transient                |
+
+`test` blocks all `build-*` jobs. If `test` fails, every build job is also cancelled — do
+not try to fix them in isolation; fix `test` first.
+
+---
+
+## Phase 1: Observe
+
+After pushing, observe the latest run on the current branch. Prefer `gh pr checks` when a PR
+exists (cleaner output), otherwise `gh run list --branch <branch>`.
+
+### 1.1 Check overall state
+
+```bash
+# If a PR is open for this branch
+gh pr checks --watch=false
+
+# Otherwise (no PR yet, e.g. just pushed a feature branch)
+gh run list --branch "$(git rev-parse --abbrev-ref HEAD)" --limit 1 \
+  --json databaseId,status,conclusion,name
+```
+
+Possible states:
+
+- `queued` / `in_progress` / `pending` → wait and re-check (Phase 1.2)
+- `completed` + `success` → done, hand off to the developer
+- `completed` + `failure` → classify and fix (Phase 2)
+- `completed` + `cancelled` → usually a dependency failed; fix the root-cause job
+- `completed` + `skipped` → not an error; only reporting jobs are typically skipped on
+  non-master branches
+
+### 1.2 Polling pattern — do NOT use `gh run watch`
+
+`gh run watch` blocks the terminal until the run finishes. In a Claude session it blocks the
+whole turn, which is both inefficient and wastes context if the run takes 10+ minutes.
+
+Instead, use the Bash tool's `run_in_background` parameter for the wait, then re-check:
+
+```bash
+# Start a background sleep matched to expected remaining time.
+# Typical CI here takes ~8–12 min end-to-end; short jobs finish in ~2 min.
+sleep 90
+```
+
+Run that with `run_in_background=true`, then on the next turn issue `gh pr checks` (or the
+`gh run list` command above) to get the updated state. Repeat until the run is `completed`.
+
+Rule of thumb for sleep durations:
+
+- First check after push: `30s` — short jobs (lint, generated-go) complete by then
+- Still in progress: `90s` — matches remaining test/build job cadence
+- Known long wait (test-pkg-js after cold image pulls): `180s`
+
+Do not poll faster than every 30 seconds — it spams the GitHub API and yields no new info.
+
+### 1.3 Get the failing run details
+
+When the overall state is `failure`:
+
+```bash
+# Identify the failing run ID from gh pr checks or gh run list output, then:
+gh run view <run-id> --json jobs \
+  --jq '.jobs[] | select(.conclusion=="failure") | {name, databaseId, conclusion}'
+```
+
+This lists only the failing jobs by name and ID — the minimum needed to decide what to fix.
+
+### 1.4 Read ONLY the failed step logs
+
+The full run log is huge and floods context. Always use `--log-failed` to get only the
+failing steps:
+
+```bash
+gh run view <run-id> --log-failed --job <job-id>
+```
+
+If the `--log-failed` output is still too large (sometimes thousands of lines for a test
+crash), pipe through `tail` or `grep` to narrow:
+
+```bash
+gh run view <run-id> --log-failed --job <job-id> | tail -n 200
+gh run view <run-id> --log-failed --job <job-id> | grep -E "FAIL|Error|error:" | head -n 50
+```
+
+Never read the full run log unprefiltered. Never fetch logs for passing jobs.
+
+---
+
+## Phase 2: Classify
+
+Once you have the failed-step log, map the failure to one of these categories. The category
+determines the fix path.
+
+### 2.1 `generated-go` failure
+
+**Symptom**: job fails with a message like `go generate definitions are not up-to-date`.
+
+**Root cause**: a `.proto` file or Go interface (used by a mock) changed without `make
+generate` being run afterward.
+
+**Fix**:
+
+```bash
+make generate
+git status --porcelain
+# Stage the regenerated files into the commit that changed the proto/interface:
+git add internal/models/proto/gen/ internal/handlers/mocks/ internal/services/mocks/
+git commit --amend --no-edit
+git push --force-with-lease
+```
+
+If the offending commit is not the most recent, use an interactive rebase — but prefer to
+surface the situation to the user first, since rewriting earlier history is unusual and the
+user may want to handle it differently.
+
+### 2.2 `lint-go` / `lint-proto` / `lint-node` failure
+
+**Symptom**: linter reports specific files + line numbers.
+
+**Fix**: run the exact make target locally, read its output, edit the flagged files, re-run
+until clean, then commit:
+
+```bash
+make lint-go        # or lint-proto / lint-node
+# edit flagged files
+make lint-go        # re-run to confirm clean
+git add <files>
+git commit -m "fix(<scope>): resolve lint findings"
+git push
+```
+
+When the lint fix is a trivial mechanical change in the same commit's scope, prefer
+`--amend` into the original commit rather than adding a noisy `fix(lint): ...` follow-up.
+When the fix is more invasive, use a new commit with a `refactor` or `fix` type.
+
+### 2.3 `test` (Go unit) failure
+
+**Symptom**: `--- FAIL: TestXxx` in the log, optionally a stack trace.
+
+**Fix**:
+
+1. Reproduce locally first — never fix blind:
+
+   ```bash
+   # Run just the failing package and test for fast iteration
+   go test ./internal/<package>/... -run TestXxx -v
+   # Or the full suite if multiple tests fail
+   make test-unit
+   ```
+
+2. Read the failure carefully. Decide: **is the test wrong, or is the code wrong?**
+   - New test for behaviour the code doesn't yet implement → fix the code
+   - Existing test that used to pass → fix the new code that broke it
+   - Test assertion out of date vs. new intended behaviour → fix the test
+   - Follow `write-go-code` / `write-go-tests` for the actual fix
+
+3. Re-run until green locally, then commit. Commit style follows `git-conventions`:
+   - If the fix belongs with the feature: `--amend` into the feature commit
+   - If it's a genuine separate fix: new `fix(<scope>)` commit
+
+4. Push and go back to Phase 1.
+
+### 2.4 `test-pkg` / `test-pkg-js` failure
+
+**Symptom**: integration test failure against a running gRPC or REST service.
+
+**First check for flake**, since these jobs depend on cold image startup:
+
+- `connection refused` / `dial tcp` / `EOF` / `context deadline exceeded` before any
+  assertion → likely flake, service wasn't ready
+- Sudden `502 Bad Gateway` or transport-level error → likely flake
+- Timeout on first request only, subsequent requests pass locally → likely flake
+
+For a suspected flake, retry the failed jobs only — do not rerun the whole workflow:
+
+```bash
+gh run rerun <run-id> --failed
+```
+
+If the same job fails twice with the same transport-level symptom, stop treating it as a
+flake and investigate as real.
+
+**If the failure is real** (assertion mismatch, wrong status code, unexpected field):
+
+1. Reproduce locally — these suites need a running service:
+
+   ```bash
+   make test-pkg       # starts gRPC standalone
+   make test-pkg-js    # starts REST standalone
+   ```
+
+2. The failure usually means a contract mismatch between handlers and client:
+   - `test-pkg` failing → gRPC handler vs. `pkg/go` client drift — check `write-proto`
+   - `test-pkg-js` failing → REST handler vs. `openapi.yaml` vs. `pkg/js/rest/` drift —
+     all three must match, see `implement-feature`'s OpenAPI / REST / JS sync rule
+
+3. Fix the out-of-date side, re-run until green, commit, push.
+
+### 2.5 `build-*` (Docker) failure
+
+**Symptom**: `docker build` step fails. Root causes:
+
+- **Go compilation error** in the image's entrypoint binary → the real failure is in Go
+  source; fix via Phase 2.3 approach (edit, `go build ./...`, commit). The `build-*`
+  failure is a downstream symptom, not the root.
+- **Dockerfile syntax / COPY path wrong** → follow `write-dockerfiles` to fix
+- **Base image pull failure** → usually transient; retry with `gh run rerun --failed`
+- **Migration init script failure** (`build-database`, `build-migrations`) → follow
+  `write-sql` for migration fixes
+
+Always read the `--log-failed` output before guessing. If the Go build fails, you'll see
+`undefined: Foo` or `type Bar has no field Baz` — those are Go issues to fix in source,
+not Dockerfile issues.
+
+### 2.6 `build-js` failure
+
+**Symptom**: `pnpm build:rest` fails in `pkg/js/`.
+
+**Fix**: follow `write-js-package`. Reproduce with `pnpm -C pkg/js build:rest`. Typical
+causes:
+
+- TypeScript compile error after an API change
+- Missing export in `pkg/js/rest/index.ts`
+- Broken import path after a file rename
+
+---
+
+## Phase 3: Fix and Re-push
+
+After applying a fix:
+
+1. Re-run the relevant local target to confirm green (`make test-unit`, `make lint-go`,
+   `make generate`, etc.)
+2. Commit per `git-conventions` — amend vs. new commit per the rules above
+3. Push. A push to the branch automatically triggers a new CI run.
+4. Return to Phase 1.
+
+Never push a fix without local verification. The goal of this loop is to use CI as
+confirmation, not as a test runner.
+
+---
+
+## Phase 4: Retry Budget and Escalation
+
+**Retry budget**: at most **3 fix attempts for the same root cause** before stopping and
+escalating to the user. If the same test keeps failing after two real fixes, the diagnosis
+is wrong — more guesses will waste time.
+
+**Flake retry budget**: at most **2 reruns via `gh run rerun --failed`** for the same
+suspected-flaky job before treating it as real. If `test-pkg-js` fails three times with
+"connection refused" across three reruns, that's a genuine problem (container startup
+regression, service crash at boot) — switch to Phase 2.4 "real" investigation.
+
+**Escalate immediately (do not spend retry budget) when:**
+
+- The failure involves a secret or credential (never debug secrets autonomously)
+- The workflow file itself is failing to parse (YAML error) — check with the user before
+  editing workflow files
+- The failure is on a reporting-only job (`report-codecov`, `publish-docs`) that does not
+  affect merge readiness — surface but do not fix unless asked
+- CI is failing _only on master_ after a merge — something slipped past review;
+  surface immediately, never push an autonomous fix to master
+- The same fix would require editing files outside the current branch's scope — stop and
+  ask
+
+**What escalation looks like**: surface to the user with (a) the failing job(s), (b) the
+root-cause hypothesis, (c) what has been tried, (d) why further attempts are not
+confidence-building.
+
+---
+
+## Phase 5: When CI is Green
+
+- If this was a push to a feature branch without a PR → hand off to `open-pull-request`
+  if the user wants to open one
+- If this was a push to an open PR → surface the all-green state and stop. Merging is a
+  developer decision unless explicitly delegated.
+- Never merge autonomously. Never add `--auto-merge` flags without an explicit instruction.
+
+---
+
+## Safety Rules
+
+- **Never push directly to `master` or `main`** — even for a trivial CI fix. All fixes go
+  via the PR branch.
+- **Never `gh workflow run` or `gh run cancel`** without explicit user permission — those
+  affect shared CI state.
+- **Never skip pre-commit hooks** (`--no-verify`) to make CI pass. If a local hook blocks
+  a commit, the same check will block CI; fix the underlying issue.
+- **Never `gh pr merge`** unless the user explicitly says to merge.
+- **Never edit `.github/workflows/*.yaml` to silence a failure** — if a check is genuinely
+  obsolete, that's a separate conversation with the user.
+- **Never autonomously re-run a failing job more than twice.** Beyond that, the failure
+  is not a flake.
+
+---
+
+## Quick Reference
+
+| Situation                             | Command                                                                             |
+| ------------------------------------- | ----------------------------------------------------------------------------------- |
+| Overall status (PR open)              | `gh pr checks --watch=false`                                                        |
+| Overall status (no PR)                | `gh run list --branch <br> --limit 1 --json databaseId,status,conclusion,name`      |
+| List failing jobs in a run            | `gh run view <run-id> --json jobs --jq '.jobs[] \| select(.conclusion=="failure")'` |
+| Read only failed-step logs of one job | `gh run view <run-id> --log-failed --job <job-id>`                                  |
+| Narrow noisy logs                     | `... \| tail -n 200` or `... \| grep -E "FAIL\|Error" \| head -n 50`                |
+| Rerun failed jobs only (flake retry)  | `gh run rerun <run-id> --failed`                                                    |
+| Wait for in-progress run              | Bash `sleep 90` with `run_in_background=true`, then re-check                        |
+
+| CI Job         | Local fix target            |
+| -------------- | --------------------------- |
+| `generated-go` | `make generate` + amend     |
+| `lint-go`      | `make lint-go`              |
+| `lint-proto`   | `make lint-proto`           |
+| `lint-node`    | `make lint-node`            |
+| `test`         | `make test-unit`            |
+| `test-pkg`     | `make test-pkg`             |
+| `test-pkg-js`  | `make test-pkg-js`          |
+| `build-js`     | `pnpm -C pkg/js build:rest` |
+| `build-*` (Go) | `go build ./...`            |

--- a/.claude/skills/monitor-ci/SKILL.md
+++ b/.claude/skills/monitor-ci/SKILL.md
@@ -202,9 +202,12 @@ the PR author at merge time if the branch uses squash-merge.
    - Test assertion out of date vs. new intended behaviour → fix the test
    - Follow `write-go-code` / `write-go-tests` for the actual fix
 
-3. Re-run until green locally, then commit. Commit style follows `git-conventions`:
-   - If the fix belongs with the feature: `--amend` into the feature commit
-   - If it's a genuine separate fix: new `fix(<scope>)` commit
+3. Re-run until green locally, then commit. `monitor-ci` always runs on an
+   already-pushed branch, so `git-conventions`' "never amend a pushed commit" rule
+   applies unconditionally:
+   - If the fix belongs with the feature: add a follow-up commit on the branch —
+     squash-merge at PR merge time (if configured) will collapse it.
+   - If it's a genuine separate fix: new `fix(<scope>)` commit.
 
 4. Push and go back to Phase 1.
 
@@ -279,7 +282,9 @@ After applying a fix:
 
 1. Re-run the relevant local target to confirm green (`make test-unit`, `make lint-go`,
    `make generate`, etc.)
-2. Commit per `git-conventions` — amend vs. new commit per the rules above
+2. Create a new fix commit per `git-conventions`. Do not amend or rewrite history on
+   this already-pushed branch — doing so strands CI run logs and review threads
+   anchored to the old SHAs.
 3. Push. A push to the branch automatically triggers a new CI run.
 4. Return to Phase 1.
 
@@ -357,7 +362,7 @@ confidence-building.
 
 | CI Job         | Local fix target            |
 | -------------- | --------------------------- |
-| `generated-go` | `make generate` + amend     |
+| `generated-go` | `make generate` + follow-up commit |
 | `lint-go`      | `make lint-go`              |
 | `lint-proto`   | `make lint-proto`           |
 | `lint-node`    | `make lint-node`            |

--- a/.claude/skills/monitor-ci/SKILL.md
+++ b/.claude/skills/monitor-ci/SKILL.md
@@ -149,7 +149,7 @@ own follow-up:
 ```bash
 make generate
 git status --porcelain
-git add internal/models/proto/gen/ internal/handlers/mocks/ internal/services/mocks/
+git add internal/handlers/protogen/ internal/handlers/mocks/ internal/services/mocks/
 git commit -m "chore(gen): regenerate Go bindings for <scope>"
 git push
 ```

--- a/.claude/skills/monitor-ci/SKILL.md
+++ b/.claude/skills/monitor-ci/SKILL.md
@@ -41,7 +41,8 @@ The `main` workflow runs on every push to any branch. Jobs and their fix targets
 | `build-rest`                                     | Docker build for REST service image        | (none)                                   | Go build error                                      |
 | `build-standalone-rest`                          | Docker build for standalone REST dev image | (none)                                   | Go build error                                      |
 | `build-js`                                       | `pnpm build:rest` for pkg/js               | `pnpm -C pkg/js build:rest`              | TS compile error or broken export                   |
-| `report-grc` / `report-codecov` / `publish-docs` | Post-success reporting (master only)       | (none)                                   | Rarely actionable; usually transient                |
+| `report-grc` / `publish-docs`                    | Post-success reporting, **master only**    | (none)                                   | Rarely actionable; usually transient                |
+| `report-codecov`                                 | Coverage upload, runs on **every branch**  | (none)                                   | Upload failure can still mark the run failed in PR checks; usually transient |
 
 `test` blocks most application `build-*` jobs (`build-grpc`, `build-rest`,
 `build-standalone-*`, `build-job-rotate-keys`). When `test` fails those downstream jobs
@@ -312,8 +313,12 @@ regression, service crash at boot) — switch to Phase 2.4 "real" investigation.
 - The failure involves a secret or credential (never debug secrets autonomously)
 - The workflow file itself is failing to parse (YAML error) — check with the user before
   editing workflow files
-- The failure is on a reporting-only job (`report-codecov`, `publish-docs`) that does not
-  affect merge readiness — surface but do not fix unless asked
+- The failure is on a master-only reporting job (`publish-docs`, `report-grc`) that does
+  not gate merges — surface but do not fix unless asked
+- The failure is on `report-codecov` — it runs on every branch and can make the workflow
+  run appear failed in PR checks even when branch protection does not gate on it. Surface
+  it; investigate only if the user asks, or if the same failure reproduces across
+  consecutive runs (a real upload or config regression rather than a transient)
 - CI is failing _only on master_ after a merge — something slipped past review;
   surface immediately, never push an autonomous fix to master
 - The same fix would require editing files outside the current branch's scope — stop and

--- a/.claude/skills/open-pull-request/SKILL.md
+++ b/.claude/skills/open-pull-request/SKILL.md
@@ -50,7 +50,9 @@ Must return empty. Uncommitted changes mean the branch is not ready. Either comm
 # name for a stacked PR (see Phase 2.3). Using master for a stacked branch would
 # include the parent's commits and validate/rewrite commits that aren't this
 # branch's responsibility.
-git log <base>..HEAD --oneline
+# %s emits the commit subject only — no abbreviated hash prefix — so each output
+# line is directly comparable against the Conventional Commits grammar below.
+git log <base>..HEAD --format=%s
 ```
 
 Every line must parse as a `git-conventions`-compliant Conventional Commit: either

--- a/.claude/skills/open-pull-request/SKILL.md
+++ b/.claude/skills/open-pull-request/SKILL.md
@@ -46,16 +46,22 @@ Must return empty. Uncommitted changes mean the branch is not ready. Either comm
 ### 1.3 Commits follow Conventional Commits
 
 ```bash
-git log master..HEAD --oneline
+# Replace <base> with master for a normal branch, or with the parent feature branch
+# name for a stacked PR (see Phase 2.3). Using master for a stacked branch would
+# include the parent's commits and validate/rewrite commits that aren't this
+# branch's responsibility.
+git log <base>..HEAD --oneline
 ```
 
-Every line must parse as `<type>(<scope>): <description>`. If any commit is malformed,
-fix it **before the branch's first push**. Use `git commit --amend` only when the
-malformed commit is the last one on the branch _and_ it has not yet been pushed; after
-the branch is pushed, `git-conventions`' "never amend a pushed commit" rule applies and
-the fix becomes a follow-up commit instead (or, for a cosmetic title fix, a PR-title
-adjustment the author can squash at merge time). For any earlier malformed commit — even
-if unpushed — ask the user before rewriting history.
+Every line must parse as a `git-conventions`-compliant Conventional Commit: either
+`<type>(<scope>): <description>` or, for genuinely cross-cutting commits where scope is
+intentionally omitted, `<type>: <description>`. If any commit is malformed, fix it
+**before the branch's first push**. Use `git commit --amend` only when the malformed
+commit is the last one on the branch _and_ it has not yet been pushed; after the branch
+is pushed, `git-conventions`' "never amend a pushed commit" rule applies and the fix
+becomes a follow-up commit instead (or, for a cosmetic title fix, a PR-title adjustment
+the author can squash at merge time). For any earlier malformed commit — even if
+unpushed — ask the user before rewriting history.
 
 ### 1.4 Local tests pass
 

--- a/.claude/skills/open-pull-request/SKILL.md
+++ b/.claude/skills/open-pull-request/SKILL.md
@@ -81,7 +81,7 @@ make generate
 git status --porcelain
 ```
 
-Any newly-modified files under `internal/models/proto/gen/`, `internal/handlers/mocks/`, or
+Any newly-modified files under `internal/handlers/protogen/`, `internal/handlers/mocks/`, or
 `internal/services/mocks/` belong with the source change that caused them. Before the
 branch's first push, amend them into the relevant commit. After the branch has been
 pushed, do not rewrite published history — add a follow-up `chore(gen): ...` commit

--- a/.claude/skills/open-pull-request/SKILL.md
+++ b/.claude/skills/open-pull-request/SKILL.md
@@ -50,8 +50,12 @@ git log master..HEAD --oneline
 ```
 
 Every line must parse as `<type>(<scope>): <description>`. If any commit is malformed,
-fix it before pushing (typically via `git commit --amend` if it is the last commit, or ask
-the user before rewriting earlier history).
+fix it **before the branch's first push**. Use `git commit --amend` only when the
+malformed commit is the last one on the branch *and* it has not yet been pushed; after
+the branch is pushed, `git-conventions`' "never amend a pushed commit" rule applies and
+the fix becomes a follow-up commit instead (or, for a cosmetic title fix, a PR-title
+adjustment the author can squash at merge time). For any earlier malformed commit — even
+if unpushed — ask the user before rewriting history.
 
 ### 1.4 Local tests pass
 
@@ -78,8 +82,11 @@ git status --porcelain
 ```
 
 Any newly-modified files under `internal/models/proto/gen/`, `internal/handlers/mocks/`, or
-`internal/services/mocks/` must be amended into the commit that caused them. CI has a
-`generated-go` job that will fail if these are stale.
+`internal/services/mocks/` belong with the source change that caused them. Before the
+branch's first push, amend them into the relevant commit. After the branch has been
+pushed, do not rewrite published history — add a follow-up `chore(gen): ...` commit
+instead (per `monitor-ci`). CI has a `generated-go` job that will fail if these are
+stale.
 
 ---
 

--- a/.claude/skills/open-pull-request/SKILL.md
+++ b/.claude/skills/open-pull-request/SKILL.md
@@ -1,0 +1,298 @@
+---
+name: open-pull-request
+description: >
+  Push the current branch and open a GitHub pull request for Agora backend services.
+  Use this skill whenever preparing to ship work — new features, fixes, refactors, chores.
+  Covers pre-flight checks, base branch selection, title and body formation, draft mode,
+  and updating an existing PR instead of re-creating it. Pairs with git-conventions for
+  commit/branch format and monitor-ci for post-push CI handling.
+---
+
+# Open Pull Request
+
+This skill governs how Claude pushes a branch and opens a pull request. Opening a PR is a
+publishing action — it notifies reviewers, triggers CI, and creates visible history. Never
+open one without the user's explicit go-ahead, and never open one from a branch that is not
+ready for review.
+
+Every PR in this repo follows the same contract: Conventional-Commits title, structured
+body, correct base, and no manual reviewer/assignee assignment (workflows handle that).
+
+---
+
+## Phase 1: Pre-Flight Checks
+
+Before any push or PR creation, verify all of the following. If any check fails, stop and
+surface the problem to the user rather than pushing.
+
+### 1.1 You are on a feature branch
+
+```bash
+git rev-parse --abbrev-ref HEAD
+```
+
+Must return something like `feat/dao/revoke-keys`, not `master` or `main`. If on `master`,
+stop — you do not open PRs from master.
+
+### 1.2 Working tree is clean
+
+```bash
+git status --porcelain
+```
+
+Must return empty. Uncommitted changes mean the branch is not ready. Either commit them
+(follow `git-conventions`) or surface them to the user.
+
+### 1.3 Commits follow Conventional Commits
+
+```bash
+git log master..HEAD --oneline
+```
+
+Every line must parse as `<type>(<scope>): <description>`. If any commit is malformed,
+fix it before pushing (typically via `git commit --amend` if it is the last commit, or ask
+the user before rewriting earlier history).
+
+### 1.4 Local tests pass
+
+Run the narrowest test target that covers the branch's layer — see `implement-feature` for
+the layer-to-target mapping. Typical:
+
+```bash
+make test-unit      # Go internal layers
+make test-pkg       # pkg/go (needs running service)
+make test-pkg-js    # pkg/js
+```
+
+If tests fail locally, CI will fail too. Fix before pushing. Never push a red branch with
+the expectation that "CI will tell me what's wrong" — that wastes a CI cycle and reviewer
+attention.
+
+### 1.5 Generated files are in sync
+
+If the branch touches `.proto` files or Go interfaces that have mocks:
+
+```bash
+make generate
+git status --porcelain
+```
+
+Any newly-modified files under `internal/models/proto/gen/`, `internal/handlers/mocks/`, or
+`internal/services/mocks/` must be amended into the commit that caused them. CI has a
+`generated-go` job that will fail if these are stale.
+
+---
+
+## Phase 2: Push the Branch
+
+### 2.1 First push — set upstream
+
+```bash
+git push -u origin $(git rev-parse --abbrev-ref HEAD)
+```
+
+The `-u` flag sets the upstream so subsequent `git push` / `git pull` need no arguments.
+
+### 2.2 Subsequent push
+
+```bash
+git push
+```
+
+If the branch has been rebased (e.g., during backtracking — see `implement-feature` Phase 4),
+force-push **with lease** to avoid clobbering anyone else's work:
+
+```bash
+git push --force-with-lease
+```
+
+Never use plain `--force`. Never force-push to `master` or `main`.
+
+### 2.3 Stacked branches
+
+If this branch depends on another open PR (e.g., `feat/services/jwk-revoke` depends on
+`feat/dao/jwk-revoke`), the base of the PR must be the parent branch, not master. Push the
+parent first and make sure its PR is already open.
+
+---
+
+## Phase 3: Decide PR Status (Ready vs. Draft)
+
+Open as **draft** when any of these apply:
+
+- The developer explicitly said "draft" or "WIP"
+- The branch is one of several stacked branches still being built — only the tip branch
+  is typically ready for review
+- The branch intentionally omits tests, docs, or a related layer that is coming later
+- The developer wants early feedback on direction before committing to a full review
+
+Otherwise open as **ready for review** (default).
+
+```bash
+gh pr create --draft ...   # draft
+gh pr create ...           # ready for review
+```
+
+---
+
+## Phase 4: Check for Existing PR
+
+Before creating a new PR, check whether one already exists for this branch:
+
+```bash
+gh pr view --json number,state,url 2>/dev/null
+```
+
+- If it returns a PR in `OPEN` state → **do not** create a new one. Update it instead
+  (see Phase 6).
+- If it returns a PR in `CLOSED` or `MERGED` state → the branch was reused. Surface this
+  to the user before doing anything else; they probably want a new branch.
+- If the command exits non-zero ("no pull requests found") → proceed to Phase 5.
+
+---
+
+## Phase 5: Create the PR
+
+### 5.1 Choose the base branch
+
+- Default: `master`
+- Stacked: the parent feature branch (e.g., `feat/dao/jwk-revoke`)
+
+Pass the base explicitly with `--base` when it is not `master`:
+
+```bash
+gh pr create --base feat/dao/jwk-revoke ...
+```
+
+### 5.2 Title
+
+The title is a Conventional-Commits line matching the primary commit on the branch. Under
+70 characters. No period.
+
+```
+feat(dao): add soft-delete repository for key revocation
+```
+
+When the branch has multiple commits touching one scope, use the scope that best describes
+the branch's goal. When the commits are genuinely cross-cutting (rename across layers), omit
+the scope.
+
+### 5.3 Body
+
+Use this template, passed via HEREDOC to preserve formatting. Skip sections that do not
+apply — do not write "no changes" placeholders.
+
+```bash
+gh pr create --title "feat(dao): add soft-delete repository for key revocation" --body "$(cat <<'EOF'
+## Summary
+
+- Adds `PgJwkRevoke` DAO for marking keys as revoked.
+- Returns `ErrJwkRevokeNotFound` when the target is already revoked or expired.
+
+## Layers changed
+
+- **DAO**: new `pg.jwkRevoke.go` + test; sentinel error added.
+
+## Breaking changes
+
+None.
+
+## Test plan
+
+- [x] `make test-unit` passes
+- [ ] CI green
+EOF
+)"
+```
+
+Rules:
+
+- **Summary** is 1–3 bullets describing what changed _and why_. Readers see the diff; they
+  need the intent.
+- **Layers changed** lists only the layers actually touched. Omit the section entirely if
+  only one layer is affected and the title already conveys it.
+- **Breaking changes** is either `None.` or an itemized list with migration steps. Never
+  leave this section as "TBD" or blank — reviewers should not have to hunt.
+- **Test plan** is a checklist. Check the boxes you have already verified locally; leave
+  `CI green` unchecked (monitor-ci will mark it).
+
+### 5.4 Do NOT pass these flags
+
+- `--assignee` / `--reviewer` — the `auto-assign-author` workflow handles assignees; the
+  repo decides reviewers via CODEOWNERS or team routing. Manual assignment duplicates or
+  conflicts with automation.
+- `--label` — labels are derived from the title's Conventional-Commits type by downstream
+  automation. Do not add them manually unless the user requests a specific one.
+- `--milestone` — project management concern; leave to humans.
+
+### 5.5 Capture the PR URL
+
+The `gh pr create` command prints the PR URL on success. Surface it to the user in the
+final message so they can jump to it.
+
+---
+
+## Phase 6: Updating an Existing PR
+
+When a PR is already open for this branch and you need to change its metadata (not code):
+
+```bash
+# Change the title
+gh pr edit --title "feat(dao): add revoke repository with soft-delete"
+
+# Replace the body (use HEREDOC as in Phase 5.3)
+gh pr edit --body "$(cat <<'EOF'
+...
+EOF
+)"
+
+# Flip from draft to ready
+gh pr ready
+
+# Flip from ready back to draft
+gh pr ready --undo
+```
+
+When the change is code, push new commits instead — the PR updates automatically. Never
+close and re-open a PR to change its code; that loses review comments and CI history.
+
+---
+
+## Phase 7: Hand-Off to monitor-ci
+
+After `gh pr create` or `git push` succeeds, CI starts. Hand off to the `monitor-ci` skill
+to watch the run, classify any failures, and apply fixes. Do not merge — merges are a
+developer decision unless explicitly delegated.
+
+---
+
+## Common Mistakes
+
+- **Pushing before local tests pass.** CI is not a debugger. Run tests locally first.
+- **Opening a PR from master.** Branch first, then PR.
+- **Closing and re-creating a PR to "fix" the title.** Use `gh pr edit --title` instead.
+- **Manual reviewer/assignee/label flags.** Automation handles these.
+- **`--force` without `--lease`.** Always `--force-with-lease` after a rebase.
+- **Missing `BREAKING CHANGE:` footer.** If any commit on the branch is breaking, the PR
+  body's Breaking Changes section must list it. Mismatches between commits and PR body are
+  bugs — readers trust the body.
+- **PR title that does not match the primary commit scope.** If the branch is `feat/dao/*`,
+  the PR title scope should be `dao`, not `services`.
+- **Linking the wrong base branch on a stacked PR.** If the parent is already merged, rebase
+  onto master and change the base to master before pushing.
+
+---
+
+## Quick Reference
+
+| Situation                           | Command                                                   |
+| ----------------------------------- | --------------------------------------------------------- |
+| First push                          | `git push -u origin <branch>`                             |
+| Push after rebase                   | `git push --force-with-lease`                             |
+| Check for existing PR               | `gh pr view --json number,state,url`                      |
+| Create ready PR                     | `gh pr create --title "..." --body "$(cat <<'EOF' ... )"` |
+| Create draft PR                     | `gh pr create --draft --title ...`                        |
+| Stacked PR (base is another branch) | `gh pr create --base feat/<parent-area>/... ...`          |
+| Update title on existing PR         | `gh pr edit --title "..."`                                |
+| Flip draft → ready                  | `gh pr ready`                                             |
+| Flip ready → draft                  | `gh pr ready --undo`                                      |

--- a/.claude/skills/open-pull-request/SKILL.md
+++ b/.claude/skills/open-pull-request/SKILL.md
@@ -51,7 +51,7 @@ git log master..HEAD --oneline
 
 Every line must parse as `<type>(<scope>): <description>`. If any commit is malformed,
 fix it **before the branch's first push**. Use `git commit --amend` only when the
-malformed commit is the last one on the branch *and* it has not yet been pushed; after
+malformed commit is the last one on the branch _and_ it has not yet been pushed; after
 the branch is pushed, `git-conventions`' "never amend a pushed commit" rule applies and
 the fix becomes a follow-up commit instead (or, for a cosmetic title fix, a PR-title
 adjustment the author can squash at merge time). For any earlier malformed commit — even

--- a/.claude/skills/open-pull-request/SKILL.md
+++ b/.claude/skills/open-pull-request/SKILL.md
@@ -232,8 +232,9 @@ Rules:
 ### 5.4 Do NOT pass these flags
 
 - `--assignee` / `--reviewer` — the `auto-assign-author` workflow handles assignees; the
-  repo decides reviewers via CODEOWNERS or team routing. Manual assignment duplicates or
-  conflicts with automation.
+  repo decides reviewers via its `CODEOWNERS` file (at repo root) or team routing. Do not
+  set reviewers manually unless the user explicitly requests a specific person; manual
+  assignment duplicates or conflicts with that automation.
 - `--label` — labels are derived from the title's Conventional-Commits type by downstream
   automation. Do not add them manually unless the user requests a specific one.
 - `--milestone` — project management concern; leave to humans.

--- a/.claude/skills/write-project-docs/SKILL.md
+++ b/.claude/skills/write-project-docs/SKILL.md
@@ -340,7 +340,6 @@ If you have questions or run into issues:
 - Open an issue at https://github.com/{{repo-path}}/issues
 - Check existing issues for similar problems
 - Include relevant logs and environment details
-
 ````
 
 **CONTRIBUTING section guidance:**
@@ -362,14 +361,14 @@ section that needs changing. Do not rewrite the file.
 
 ### Typical update operations
 
-| Request                               | Action                                                                   |
-| ------------------------------------- | ------------------------------------------------------------------------ |
-| "Bump the Docker image tags in README"| Edit every `image: ghcr.io/.../…:vX.Y.Z` line to the new version        |
-| "Add env var FOO to README"           | Add a new row to the matching config-vars table                          |
-| "Change security contact"             | Edit `{{security-email}}` occurrence in SECURITY.md                      |
-| "New gRPC service added"              | Add row to the gRPC services table in CONTRIBUTING.md                    |
-| "Project got a JS client"             | Add the JS usage section to README, add JS client section to CONTRIBUTING, flip `has-js-client` on |
-| "Remove deprecated ENV var"           | Delete the table row in README; surface to user since removal may be breaking |
+| Request                                | Action                                                                                             |
+| -------------------------------------- | -------------------------------------------------------------------------------------------------- |
+| "Bump the Docker image tags in README" | Edit every `image: ghcr.io/.../…:vX.Y.Z` line to the new version                                   |
+| "Add env var FOO to README"            | Add a new row to the matching config-vars table                                                    |
+| "Change security contact"              | Edit `{{security-email}}` occurrence in SECURITY.md                                                |
+| "New gRPC service added"               | Add row to the gRPC services table in CONTRIBUTING.md                                              |
+| "Project got a JS client"              | Add the JS usage section to README, add JS client section to CONTRIBUTING, flip `has-js-client` on |
+| "Remove deprecated ENV var"            | Delete the table row in README; surface to user since removal may be breaking                      |
 
 ### Update rules
 
@@ -390,17 +389,17 @@ section that needs changing. Do not rewrite the file.
 Copy these patterns verbatim — the exact URL format matters (shields.io is strict about
 path segments). Parameters are clearly marked with `{{…}}`.
 
-| Badge                    | Markdown pattern                                                                                                                                        |
-| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Twitter follow           | `[![X (formerly Twitter) Follow](https://img.shields.io/twitter/follow/{{handle}})](https://twitter.com/{{handle}})`                                    |
-| Discord                  | `[![Discord](https://img.shields.io/discord/{{discord-id}}?logo=discord)](https://discord.gg/{{invite-code}})`                                          |
-| Go version (from go.mod) | `![GitHub go.mod Go version](https://img.shields.io/github/go-mod/go-version/{{repo-path}})`                                                            |
-| File count               | `![GitHub repo file or directory count](https://img.shields.io/github/directory-file-count/{{repo-path}})`                                              |
-| Code size                | `![GitHub code size in bytes](https://img.shields.io/github/languages/code-size/{{repo-path}})`                                                         |
-| CI workflow status       | `![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/{{repo-path}}/{{main-workflow-file}})`                         |
-| Go Report Card           | `[![Go Report Card](https://goreportcard.com/badge/github.com/{{repo-path}})](https://goreportcard.com/report/github.com/{{repo-path}})`                |
-| Codecov badge            | `[![codecov](https://codecov.io/gh/{{repo-path}}/graph/badge.svg?token={{codecov-graph-token}})](https://codecov.io/gh/{{repo-path}})`                  |
-| Codecov sunburst         | `![Coverage graph](https://codecov.io/gh/{{repo-path}}/graphs/sunburst.svg?token={{codecov-graph-token}})`                                              |
+| Badge                    | Markdown pattern                                                                                                                         |
+| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| Twitter follow           | `[![X (formerly Twitter) Follow](https://img.shields.io/twitter/follow/{{handle}})](https://twitter.com/{{handle}})`                     |
+| Discord                  | `[![Discord](https://img.shields.io/discord/{{discord-id}}?logo=discord)](https://discord.gg/{{invite-code}})`                           |
+| Go version (from go.mod) | `![GitHub go.mod Go version](https://img.shields.io/github/go-mod/go-version/{{repo-path}})`                                             |
+| File count               | `![GitHub repo file or directory count](https://img.shields.io/github/directory-file-count/{{repo-path}})`                               |
+| Code size                | `![GitHub code size in bytes](https://img.shields.io/github/languages/code-size/{{repo-path}})`                                          |
+| CI workflow status       | `![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/{{repo-path}}/{{main-workflow-file}})`          |
+| Go Report Card           | `[![Go Report Card](https://goreportcard.com/badge/github.com/{{repo-path}})](https://goreportcard.com/report/github.com/{{repo-path}})` |
+| Codecov badge            | `[![codecov](https://codecov.io/gh/{{repo-path}}/graph/badge.svg?token={{codecov-graph-token}})](https://codecov.io/gh/{{repo-path}})`   |
+| Codecov sunburst         | `![Coverage graph](https://codecov.io/gh/{{repo-path}}/graphs/sunburst.svg?token={{codecov-graph-token}})`                               |
 
 **Codecov graph token — not a secret.** It is the public badge token from
 `codecov.io/gh/<repo>/settings > Badge`. Committing it is intentional. The private upload

--- a/.claude/skills/write-project-docs/SKILL.md
+++ b/.claude/skills/write-project-docs/SKILL.md
@@ -1,0 +1,460 @@
+---
+name: write-project-docs
+description: >
+  Write, review, and maintain the root-level project documentation — README.md, SECURITY.md,
+  CONTRIBUTING.md — for Agora backend services. Use this skill whenever scaffolding a new
+  project's docs, updating an existing README/SECURITY/CONTRIBUTING (new env var, new badge,
+  new client section, security contact change), or adding sections like client usage or
+  Docker examples. Does NOT cover CODE_OF_CONDUCT.md (standard Contributor Covenant, copy
+  verbatim) or in-source code comments (use document-code).
+---
+
+# Project Docs
+
+This skill governs the three root-level Markdown files that describe a project to external
+readers: `README.md`, `SECURITY.md`, `CONTRIBUTING.md`. These files are the first thing
+visitors see; they set expectations for usage, security contact, and how to contribute. They
+must be accurate, scannable, and consistent across all Agora services.
+
+The skill has two modes:
+
+- **Scaffold** — the file does not exist yet (new project). Generate from the templates in
+  this skill, substituting project-specific inputs.
+- **Update** — the file exists. Edit the relevant section in place. Never overwrite a whole
+  file when the ask is to change one section.
+
+Separate concerns:
+
+- `CODE_OF_CONDUCT.md` — **not managed by this skill.** Copy the Contributor Covenant
+  verbatim from <https://www.contributor-covenant.org/version/2/1/code_of_conduct.md>
+  when setting up a new project and do not edit further.
+- `document-code` — governs doc comments inside source files (Go, SQL, TS, etc.), not these
+  project-level Markdown files.
+
+---
+
+## Phase 1: Collect Required Inputs
+
+Before scaffolding a new file, ask the user for the inputs below. When running in **update**
+mode, only ask for the inputs that are relevant to the section being edited.
+
+Collect them in a single message rather than asking one question at a time.
+
+### 1.1 Always required
+
+| Input                | Example                     | Default for Agora        |
+| -------------------- | --------------------------- | ------------------------ |
+| Project display name | `JSON Keys service`         | (ask)                    |
+| Repo path (org/repo) | `a-novel/service-json-keys` | `a-novel/<service-slug>` |
+| Main branch          | `master`                    | `master`                 |
+
+### 1.2 Required for README.md
+
+| Input               | Example                                                   | Default / Fallback                                                              |
+| ------------------- | --------------------------------------------------------- | ------------------------------------------------------------------------------- |
+| Main CI workflow    | `main.yaml`                                               | `main.yaml`                                                                     |
+| Codecov graph token | `almKepuGQE` (public token, safe to commit)               | `<!-- TODO(project-docs): fetch from codecov.io/gh/<repo>/settings > Badge -->` |
+| Twitter handle      | `agorastoryverse`                                         | `agorastoryverse`                                                               |
+| Discord invite ID   | numeric ID `1315240114691248138` + invite code `rp4Qr8cA` | same as existing services                                                       |
+
+The codecov graph token is **public** — it only controls badge/graph rendering, not repo
+access. Safe to commit. The private upload token lives in CI secrets, never in docs.
+
+### 1.3 Required for SECURITY.md
+
+| Input                       | Example                                | Default                                |
+| --------------------------- | -------------------------------------- | -------------------------------------- |
+| Org / project display label | `A-Novel` (used in running prose)      | `A-Novel`                              |
+| Security contact email      | `geoffroy.vincent@agorastoryverse.com` | `geoffroy.vincent@agorastoryverse.com` |
+
+### 1.4 Required for CONTRIBUTING.md
+
+| Input                | Example                                       | Default                                       |
+| -------------------- | --------------------------------------------- | --------------------------------------------- |
+| Project slug         | `service-json-keys`                           | (ask — used in page title)                    |
+| Org contributing URL | `a-novel/.github/blob/master/CONTRIBUTING.md` | `a-novel/.github/blob/master/CONTRIBUTING.md` |
+
+### 1.5 Capability flags (shape template output)
+
+Ask the user which of these apply. Each flag turns a section of README/CONTRIBUTING on or
+off:
+
+| Flag               | What it enables                                                     |
+| ------------------ | ------------------------------------------------------------------- |
+| `has-grpc`         | gRPC compose examples + `grpcurl` interaction snippets              |
+| `has-rest`         | REST compose examples + `curl` interaction snippets                 |
+| `has-standalone`   | Standalone (all-in-one) image in addition to split images           |
+| `has-go-client`    | `pkg/go` usage example in README, Go client section in CONTRIBUTING |
+| `has-js-client`    | `pkg/js` usage example in README, JS client section in CONTRIBUTING |
+| `has-openapi-docs` | Link to GitHub Pages docs in README + redocly/scalar mention        |
+| `has-cron-jobs`    | Scheduled-job section (like rotate-keys) in CONTRIBUTING            |
+
+When an input is unknown or the user declines to provide it, insert an HTML TODO comment
+(see [Handling Missing Values](#handling-missing-values)) rather than guessing or leaving
+the field blank.
+
+---
+
+## Phase 2: Detect Scaffold vs. Update
+
+```bash
+ls README.md SECURITY.md CONTRIBUTING.md 2>/dev/null
+```
+
+- File missing → scaffold mode: generate from template in Phase 4
+- File present → update mode: read it first, edit the relevant section only (Phase 5)
+
+Never overwrite an existing file with the full template. Users may have added custom
+sections (architecture diagrams, org-specific footers, release notes) that are not in the
+template — replacing the file silently drops them.
+
+---
+
+## Phase 3: Handling Missing Values
+
+When an input is required but not available, write an HTML TODO comment at the exact
+location where the value belongs. Format:
+
+```markdown
+<!-- TODO(project-docs): <what is missing> — <where to get it> -->
+```
+
+HTML comments do not render in GitHub's Markdown preview, so the file still looks clean to
+visitors, but grep finds them instantly:
+
+```bash
+grep -rn "TODO(project-docs)" .
+```
+
+Examples:
+
+```markdown
+[![codecov](https://codecov.io/gh/a-novel/service-json-keys/graph/badge.svg?token=<!-- TODO(project-docs): codecov graph token from codecov.io/gh/a-novel/service-json-keys/settings > Badge -->)](https://codecov.io/gh/a-novel/service-json-keys)
+```
+
+```markdown
+Report security bugs by emailing the lead maintainer at <!-- TODO(project-docs): security contact email -->.
+```
+
+**Do not** invent values. A fake email or a placeholder like `YOUR_TOKEN_HERE` that a
+reader might mistake for real content is worse than a visible TODO.
+
+---
+
+## Phase 4: Scaffold Templates
+
+All three templates below use `{{variable}}` placeholders. Substitute every placeholder
+with the inputs from Phase 1 before writing the file. Do not leave `{{…}}` in the output
+— unresolved placeholders are a bug.
+
+### 4.1 README.md template
+
+```markdown
+# {{project-display-name}}
+
+[![X (formerly Twitter) Follow](https://img.shields.io/twitter/follow/{{twitter-handle}})](https://twitter.com/{{twitter-handle}})
+[![Discord](https://img.shields.io/discord/{{discord-id}}?logo=discord)](https://discord.gg/{{discord-invite-code}})
+
+<hr />
+
+![GitHub go.mod Go version](https://img.shields.io/github/go-mod/go-version/{{repo-path}})
+![GitHub repo file or directory count](https://img.shields.io/github/directory-file-count/{{repo-path}})
+![GitHub code size in bytes](https://img.shields.io/github/languages/code-size/{{repo-path}})
+
+![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/{{repo-path}}/{{main-workflow-file}})
+[![Go Report Card](https://goreportcard.com/badge/github.com/{{repo-path}})](https://goreportcard.com/report/github.com/{{repo-path}})
+[![codecov](https://codecov.io/gh/{{repo-path}}/graph/badge.svg?token={{codecov-graph-token}})](https://codecov.io/gh/{{repo-path}})
+
+![Coverage graph](https://codecov.io/gh/{{repo-path}}/graphs/sunburst.svg?token={{codecov-graph-token}})
+
+## Usage
+
+<!-- Include the sub-sections below only when the corresponding capability flag is set. -->
+
+### Docker
+
+<!-- If has-grpc: include the gRPC compose block(s). -->
+<!-- If has-rest: include the REST compose block(s). -->
+<!-- If has-standalone: include both the standalone and split-image variants for each protocol. -->
+
+Above are the minimal required configuration to run the service locally. Configuration is
+done through environment variables. Below is a list of available configurations:
+
+**Required variables**
+
+| Name | Description | Images |
+| ---- | ----------- | ------ |
+
+<!-- One row per required env var. -->
+
+**Optional variables**
+
+<!-- Group by concern: REST API, Logs & Tracing, etc. One table per group. -->
+
+<!-- If has-js-client: include the JS/npm usage section. -->
+<!-- If has-go-client: include the Go module usage section. -->
+```
+
+**README section guidance:**
+
+- The six badges in the catalog always appear in the order shown (socials, then repo metrics,
+  then CI/coverage). Deviating breaks the visual rhythm across services.
+- The `<hr />` literal (not `---`) separates the social badges from the repo metrics — this
+  matches the existing Agora convention.
+- Docker compose examples must pin images by tag (e.g., `:v2.2.6`), never `:latest`. When
+  scaffolding, ask the user for the current release version or write a
+  `<!-- TODO(project-docs): current image tag (see GitHub releases) -->` placeholder.
+- The config-vars tables use `<br/>` to stack multiple image names in a single cell —
+  keeps the table narrow.
+- Client usage snippets should demonstrate the **minimum viable call** (ping + one real
+  operation), not every available method. Readers will find the rest in the API reference.
+
+### 4.2 SECURITY.md template
+
+This file is near-boilerplate. Only `{{org-label}}` and `{{security-email}}` are
+substituted. Do not rewrite the boilerplate to "improve" it — consistency across Agora
+services matters more than prose polish.
+
+```markdown
+# Security Policies and Procedures
+
+This document outlines security procedures and general policies for the `{{org-label}}`
+project.
+
+- [Reporting a Bug](#reporting-a-bug)
+- [Disclosure Policy](#disclosure-policy)
+- [Comments on this Policy](#comments-on-this-policy)
+
+## Reporting a Bug
+
+The `{{org-label}}` team and community take all security bugs in `{{org-label}}` seriously.
+Thank you for improving the security of `{{org-label}}`. We appreciate your efforts and
+responsible disclosure and will make every effort to acknowledge your
+contributions.
+
+Report security bugs by emailing the lead maintainer at {{security-email}}.
+
+The lead maintainer will acknowledge your email within 48 hours, and will send a
+more detailed response within 48 hours indicating the next steps in handling
+your report. After the initial reply to your report, the security team will
+endeavor to keep you informed of the progress towards a fix and full
+announcement, and may ask for additional information or guidance.
+
+Report security bugs in third-party modules to the person or team maintaining
+the module.
+
+## Disclosure Policy
+
+When the security team receives a security bug report, they will assign it to a
+primary handler. This person will coordinate the fix and release process,
+involving the following steps:
+
+- Confirm the problem and determine the affected versions.
+- Audit code to find any potential similar problems.
+- Prepare fixes for all releases still under maintenance. These fixes will be
+  released as fast as possible.
+
+## Comments on this Policy
+
+If you have suggestions on how this process could be improved please submit a
+pull request.
+```
+
+### 4.3 CONTRIBUTING.md template
+
+````markdown
+# Contributing to {{project-slug}}
+
+Welcome to the {{project-display-name}} for the A-Novel platform. This guide will help you understand the codebase, set
+up your development environment, and contribute effectively.
+
+Before reading this guide, if you haven't already, please check the
+[generic contribution guidelines](https://github.com/{{org-contributing-url}}) that are relevant
+to your scope.
+
+---
+
+## Quick Start
+
+### Prerequisites
+
+The following must be installed on your system.
+
+- [Go](https://go.dev/doc/install)
+- [Node.js](https://nodejs.org/en/download)
+  - [pnpm](https://pnpm.io/installation)
+- [Podman](https://podman.io/docs/installation)
+- (optional) [Direnv](https://direnv.net/)
+- Make
+  - `sudo apt-get install build-essential` (apt)
+  - `sudo pacman -S make` (arch)
+  - `brew install make` (macOS)
+  - [Make for Windows](https://gnuwin32.sourceforge.net/packages/make.htm)
+
+### Bootstrap
+
+Install the dependencies:
+
+```bash
+make install
+```
+````
+
+### Common Commands
+
+| Command         | Description                      |
+| --------------- | -------------------------------- |
+| `make run`      | Start all services locally       |
+| `make test`     | Run all tests                    |
+| `make lint`     | Run all linters                  |
+| `make format`   | Format all code                  |
+| `make build`    | Build Docker images locally      |
+| `make generate` | Generate mocks and protobuf code |
+
+### Interacting with the Service
+
+<!-- If has-rest: include REST interaction snippets (curl). -->
+<!-- If has-grpc: include gRPC interaction snippets (grpcurl). -->
+
+---
+
+## Project-Specific Guidelines
+
+> This section contains patterns specific to this {{project-display-name}}.
+
+<!-- TODO(project-docs): document the project-specific patterns — typical sections:
+     - domain concepts (what the service owns / produces)
+     - lifecycle of the primary entity (states, transitions)
+     - key configuration files and what they control
+     - scheduled jobs / cron
+     - gRPC services table (if has-grpc)
+     - REST API overview (if has-rest)
+     - client packages (if has-go-client / has-js-client)
+-->
+
+---
+
+## Questions?
+
+If you have questions or run into issues:
+
+- Open an issue at https://github.com/{{repo-path}}/issues
+- Check existing issues for similar problems
+- Include relevant logs and environment details
+
+````
+
+**CONTRIBUTING section guidance:**
+
+- The **Quick Start** and **Questions** sections are identical across all Agora services.
+  Do not customize them per project — that creates drift.
+- The **Interacting with the Service** section varies only by protocol (REST vs. gRPC).
+  Use the capability flags to include/exclude snippets.
+- The **Project-Specific Guidelines** section is bespoke. The template leaves a TODO
+  comment listing common sub-sections (domain concepts, lifecycle, config, etc.) — the
+  user fills these in based on the project. Do not invent content.
+
+---
+
+## Phase 5: Update Mode
+
+When one of the three files already exists, `Read` it first, then `Edit` the specific
+section that needs changing. Do not rewrite the file.
+
+### Typical update operations
+
+| Request                               | Action                                                                   |
+| ------------------------------------- | ------------------------------------------------------------------------ |
+| "Bump the Docker image tags in README"| Edit every `image: ghcr.io/.../…:vX.Y.Z` line to the new version        |
+| "Add env var FOO to README"           | Add a new row to the matching config-vars table                          |
+| "Change security contact"             | Edit `{{security-email}}` occurrence in SECURITY.md                      |
+| "New gRPC service added"              | Add row to the gRPC services table in CONTRIBUTING.md                    |
+| "Project got a JS client"             | Add the JS usage section to README, add JS client section to CONTRIBUTING, flip `has-js-client` on |
+| "Remove deprecated ENV var"           | Delete the table row in README; surface to user since removal may be breaking |
+
+### Update rules
+
+- **Preserve unknown content.** If the file has sections you don't recognize (custom
+  architecture notes, team-specific tips), leave them untouched.
+- **One logical edit per call.** When adding a new env var, update only that table; do not
+  also "touch up" unrelated sections while there.
+- **Check for stale cross-references.** Adding a new gRPC service to the CONTRIBUTING
+  table means the README's service list (if any) needs the same row.
+- **Version bumps touch every occurrence.** A release bump affects every compose YAML in
+  the README — use `Edit` with `replace_all` only when you have verified the old string is
+  unique to the version (e.g., `:v2.2.6`), otherwise do it one-by-one.
+
+---
+
+## Badge Catalog
+
+Copy these patterns verbatim — the exact URL format matters (shields.io is strict about
+path segments). Parameters are clearly marked with `{{…}}`.
+
+| Badge                    | Markdown pattern                                                                                                                                        |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Twitter follow           | `[![X (formerly Twitter) Follow](https://img.shields.io/twitter/follow/{{handle}})](https://twitter.com/{{handle}})`                                    |
+| Discord                  | `[![Discord](https://img.shields.io/discord/{{discord-id}}?logo=discord)](https://discord.gg/{{invite-code}})`                                          |
+| Go version (from go.mod) | `![GitHub go.mod Go version](https://img.shields.io/github/go-mod/go-version/{{repo-path}})`                                                            |
+| File count               | `![GitHub repo file or directory count](https://img.shields.io/github/directory-file-count/{{repo-path}})`                                              |
+| Code size                | `![GitHub code size in bytes](https://img.shields.io/github/languages/code-size/{{repo-path}})`                                                         |
+| CI workflow status       | `![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/{{repo-path}}/{{main-workflow-file}})`                         |
+| Go Report Card           | `[![Go Report Card](https://goreportcard.com/badge/github.com/{{repo-path}})](https://goreportcard.com/report/github.com/{{repo-path}})`                |
+| Codecov badge            | `[![codecov](https://codecov.io/gh/{{repo-path}}/graph/badge.svg?token={{codecov-graph-token}})](https://codecov.io/gh/{{repo-path}})`                  |
+| Codecov sunburst         | `![Coverage graph](https://codecov.io/gh/{{repo-path}}/graphs/sunburst.svg?token={{codecov-graph-token}})`                                              |
+
+**Codecov graph token — not a secret.** It is the public badge token from
+`codecov.io/gh/<repo>/settings > Badge`. Committing it is intentional. The private upload
+token (used by the CI `report-codecov` job) lives in repo secrets, never here.
+
+---
+
+## Portability to New Projects
+
+This skill lives in this repo's `.claude/skills/write-project-docs/`. To reuse it in a new
+Agora service:
+
+1. Copy the directory into the new repo's `.claude/skills/`:
+
+   ```bash
+   cp -r /path/to/this-repo/.claude/skills/write-project-docs \
+         /path/to/new-repo/.claude/skills/
+````
+
+2. In the new repo, invoke the skill (Claude picks it up once the file exists). Phase 1
+   will collect the new project's inputs.
+
+3. The templates are intentionally Agora-flavoured (mentions of `make` targets, podman,
+   `.github/CONTRIBUTING.md`, etc.). That is a feature, not a bug — it keeps docs consistent
+   across services. When a new project legitimately deviates (different tooling, different
+   org), update the templates in place rather than forking them.
+
+---
+
+## What NOT to Do
+
+- **Do not edit `CODE_OF_CONDUCT.md`.** It's the Contributor Covenant verbatim. Changes to
+  it are org-wide policy, not per-repo.
+- **Do not add "Live Demo" / "Screenshots" / "Roadmap" sections** unless the user asks.
+  They become stale fast and aren't in the Agora template.
+- **Do not write long prose.** README and CONTRIBUTING are reference documents. Tables,
+  bullet lists, and runnable code blocks beat paragraphs.
+- **Do not embed secrets.** The codecov graph token is fine (public). API keys, passwords,
+  real `APP_MASTER_KEY` values, npm auth tokens are not.
+- **Do not link to internal-only dashboards.** Anything linked in the README is
+  publicly visible once the repo is public.
+- **Do not invent version numbers or email addresses** to fill placeholders. Use the TODO
+  comment pattern.
+
+---
+
+## Quick Reference
+
+| Situation                                    | Skill phase                                                  |
+| -------------------------------------------- | ------------------------------------------------------------ |
+| New project, all docs missing                | Phase 1 (collect inputs) → Phase 4 (scaffold all three)      |
+| "Add env var X to README"                    | Phase 5 (update mode, edit the config table)                 |
+| "Update security contact email"              | Phase 5 (edit SECURITY.md only)                              |
+| "Docs for a project split off from monorepo" | Phase 1 → Phase 4, then port custom sections from the parent |
+| "Port these skills to new-repo"              | [Portability to New Projects](#portability-to-new-projects)  |
+| Required value unavailable                   | [Handling Missing Values](#phase-3-handling-missing-values)  |

--- a/.claude/skills/write-project-docs/SKILL.md
+++ b/.claude/skills/write-project-docs/SKILL.md
@@ -390,17 +390,17 @@ section that needs changing. Do not rewrite the file.
 Copy these patterns verbatim — the exact URL format matters (shields.io is strict about
 path segments). Parameters are clearly marked with `{{…}}`.
 
-| Badge                    | Markdown pattern                                                                                                                         |
-| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------- |
-| Twitter follow           | `[![X (formerly Twitter) Follow](https://img.shields.io/twitter/follow/{{twitter-handle}})](https://twitter.com/{{twitter-handle}})`     |
-| Discord                  | `[![Discord](https://img.shields.io/discord/{{discord-id}}?logo=discord)](https://discord.gg/{{discord-invite-code}})`                   |
-| Go version (from go.mod) | `![GitHub go.mod Go version](https://img.shields.io/github/go-mod/go-version/{{repo-path}})`                                             |
-| File count               | `![GitHub repo file or directory count](https://img.shields.io/github/directory-file-count/{{repo-path}})`                               |
-| Code size                | `![GitHub code size in bytes](https://img.shields.io/github/languages/code-size/{{repo-path}})`                                          |
-| CI workflow status       | `![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/{{repo-path}}/{{main-workflow-file}})`          |
-| Go Report Card           | `[![Go Report Card](https://goreportcard.com/badge/github.com/{{repo-path}})](https://goreportcard.com/report/github.com/{{repo-path}})` |
+| Badge                    | Markdown pattern                                                                                                                                                                                                                     |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Twitter follow           | `[![X (formerly Twitter) Follow](https://img.shields.io/twitter/follow/{{twitter-handle}})](https://twitter.com/{{twitter-handle}})`                                                                                                 |
+| Discord                  | `[![Discord](https://img.shields.io/discord/{{discord-id}}?logo=discord)](https://discord.gg/{{discord-invite-code}})`                                                                                                               |
+| Go version (from go.mod) | `![GitHub go.mod Go version](https://img.shields.io/github/go-mod/go-version/{{repo-path}})`                                                                                                                                         |
+| File count               | `![GitHub repo file or directory count](https://img.shields.io/github/directory-file-count/{{repo-path}})`                                                                                                                           |
+| Code size                | `![GitHub code size in bytes](https://img.shields.io/github/languages/code-size/{{repo-path}})`                                                                                                                                      |
+| CI workflow status       | `![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/{{repo-path}}/{{main-workflow-file}})`                                                                                                      |
+| Go Report Card           | `[![Go Report Card](https://goreportcard.com/badge/github.com/{{repo-path}})](https://goreportcard.com/report/github.com/{{repo-path}})`                                                                                             |
 | Codecov badge            | Default (no token): `[![codecov](https://codecov.io/gh/{{repo-path}}/graph/badge.svg)](https://codecov.io/gh/{{repo-path}})` — add `?token={{codecov-graph-token}}` to the badge URL only when the repo requires a tokenized variant |
-| Codecov sunburst         | Default (no token): `![Coverage graph](https://codecov.io/gh/{{repo-path}}/graphs/sunburst.svg)` — add `?token={{codecov-graph-token}}` to the image URL only when a tokenized variant is required                                  |
+| Codecov sunburst         | Default (no token): `![Coverage graph](https://codecov.io/gh/{{repo-path}}/graphs/sunburst.svg)` — add `?token={{codecov-graph-token}}` to the image URL only when a tokenized variant is required                                   |
 
 **Codecov graph token — not a secret.** It is the public badge token from
 `codecov.io/gh/<repo>/settings > Badge`. Committing it is intentional. The private upload

--- a/.claude/skills/write-project-docs/SKILL.md
+++ b/.claude/skills/write-project-docs/SKILL.md
@@ -50,12 +50,12 @@ Collect them in a single message rather than asking one question at a time.
 
 ### 1.2 Required for README.md
 
-| Input               | Example                                                   | Default / Fallback                                                              |
-| ------------------- | --------------------------------------------------------- | ------------------------------------------------------------------------------- |
-| Main CI workflow    | `main.yaml`                                               | `main.yaml`                                                                     |
-| Codecov graph token | `almKepuGQE` (public token, safe to commit)               | `<!-- TODO(project-docs): fetch from codecov.io/gh/<repo>/settings > Badge -->` |
-| Twitter handle      | `agorastoryverse`                                         | `agorastoryverse`                                                               |
-| Discord invite ID   | numeric ID `1315240114691248138` + invite code `rp4Qr8cA` | same as existing services                                                       |
+| Input               | Example                                                   | Default / Fallback                                                                                       |
+| ------------------- | --------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| Main CI workflow    | `main.yaml`                                               | `main.yaml`                                                                                              |
+| Codecov graph token | `almKepuGQE` (public token, safe to commit)               | Omit the `?token=…` query parameter entirely and leave a `TODO(project-docs)` comment next to the badge. |
+| Twitter handle      | `agorastoryverse`                                         | `agorastoryverse`                                                                                        |
+| Discord invite ID   | numeric ID `1315240114691248138` + invite code `rp4Qr8cA` | same as existing services                                                                                |
 
 The codecov graph token is **public** — it only controls badge/graph rendering, not repo
 access. Safe to commit. The private upload token lives in CI secrets, never in docs.
@@ -129,7 +129,7 @@ grep -rn "TODO(project-docs)" .
 Examples:
 
 ```markdown
-[![codecov](https://codecov.io/gh/a-novel/service-json-keys/graph/badge.svg?token=<!-- TODO(project-docs): codecov graph token from codecov.io/gh/a-novel/service-json-keys/settings > Badge -->)](https://codecov.io/gh/a-novel/service-json-keys)
+[![codecov](https://codecov.io/gh/a-novel/service-json-keys/graph/badge.svg)](https://codecov.io/gh/a-novel/service-json-keys) <!-- TODO(project-docs): add ?token=<graph-token> from codecov.io/gh/a-novel/service-json-keys/settings > Badge if a tokenized badge is required -->
 ```
 
 ```markdown

--- a/.claude/skills/write-project-docs/SKILL.md
+++ b/.claude/skills/write-project-docs/SKILL.md
@@ -366,7 +366,7 @@ section that needs changing. Do not rewrite the file.
 | -------------------------------------- | -------------------------------------------------------------------------------------------------- |
 | "Bump the Docker image tags in README" | Edit every `image: ghcr.io/.../…:vX.Y.Z` line to the new version                                   |
 | "Add env var FOO to README"            | Add a new row to the matching config-vars table                                                    |
-| "Change security contact"              | Edit `{{security-email}}` occurrence in SECURITY.md                                                |
+| "Change security contact"              | Edit the existing email address on the `Report security bugs...` line in SECURITY.md              |
 | "New gRPC service added"               | Add row to the gRPC services table in CONTRIBUTING.md                                              |
 | "Project got a JS client"              | Add the JS usage section to README, add JS client section to CONTRIBUTING, flip `has-js-client` on |
 | "Remove deprecated ENV var"            | Delete the table row in README; surface to user since removal may be breaking                      |

--- a/.claude/skills/write-project-docs/SKILL.md
+++ b/.claude/skills/write-project-docs/SKILL.md
@@ -366,7 +366,7 @@ section that needs changing. Do not rewrite the file.
 | -------------------------------------- | -------------------------------------------------------------------------------------------------- |
 | "Bump the Docker image tags in README" | Edit every `image: ghcr.io/.../…:vX.Y.Z` line to the new version                                   |
 | "Add env var FOO to README"            | Add a new row to the matching config-vars table                                                    |
-| "Change security contact"              | Edit the existing email address on the `Report security bugs...` line in SECURITY.md              |
+| "Change security contact"              | Edit the existing email address on the `Report security bugs...` line in SECURITY.md               |
 | "New gRPC service added"               | Add row to the gRPC services table in CONTRIBUTING.md                                              |
 | "Project got a JS client"              | Add the JS usage section to README, add JS client section to CONTRIBUTING, flip `has-js-client` on |
 | "Remove deprecated ENV var"            | Delete the table row in README; surface to user since removal may be breaking                      |

--- a/.claude/skills/write-project-docs/SKILL.md
+++ b/.claude/skills/write-project-docs/SKILL.md
@@ -163,9 +163,9 @@ with the inputs from Phase 1 before writing the file. Do not leave `{{…}}` in 
 
 ![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/{{repo-path}}/{{main-workflow-file}})
 [![Go Report Card](https://goreportcard.com/badge/github.com/{{repo-path}})](https://goreportcard.com/report/github.com/{{repo-path}})
-[![codecov](https://codecov.io/gh/{{repo-path}}/graph/badge.svg?token={{codecov-graph-token}})](https://codecov.io/gh/{{repo-path}})
+[![codecov](https://codecov.io/gh/{{repo-path}}/graph/badge.svg)](https://codecov.io/gh/{{repo-path}}) <!-- TODO(project-docs): if this repo requires a tokenized Codecov badge, append `?token=<codecov-graph-token>` to the badge URL above using the value from codecov.io/gh/{{repo-path}}/settings > Badge -->
 
-![Coverage graph](https://codecov.io/gh/{{repo-path}}/graphs/sunburst.svg?token={{codecov-graph-token}})
+![Coverage graph](https://codecov.io/gh/{{repo-path}}/graphs/sunburst.svg) <!-- TODO(project-docs): if this repo requires a tokenized Codecov sunburst, append `?token=<codecov-graph-token>` to the image URL above -->
 
 ## Usage
 

--- a/.claude/skills/write-project-docs/SKILL.md
+++ b/.claude/skills/write-project-docs/SKILL.md
@@ -298,7 +298,6 @@ Install the dependencies:
 ```bash
 make install
 ```
-````
 
 ### Common Commands
 
@@ -419,7 +418,7 @@ Agora service:
    ```bash
    cp -r /path/to/this-repo/.claude/skills/write-project-docs \
          /path/to/new-repo/.claude/skills/
-````
+   ```
 
 2. In the new repo, invoke the skill (Claude picks it up once the file exists). Phase 1
    will collect the new project's inputs.

--- a/.claude/skills/write-project-docs/SKILL.md
+++ b/.claude/skills/write-project-docs/SKILL.md
@@ -197,8 +197,9 @@ done through environment variables. Below is a list of available configurations:
 
 **README section guidance:**
 
-- The six badges in the catalog always appear in the order shown (socials, then repo metrics,
-  then CI/coverage). Deviating breaks the visual rhythm across services.
+- The nine entries in the catalog (two socials + three repo metrics + four CI/coverage,
+  counting the Codecov sunburst) always appear in the order shown. Deviating breaks the
+  visual rhythm across services.
 - The `<hr />` literal (not `---`) separates the social badges from the repo metrics — this
   matches the existing Agora convention.
 - Docker compose examples must pin images by tag (e.g., `:v2.2.6`), never `:latest`. When
@@ -391,15 +392,15 @@ path segments). Parameters are clearly marked with `{{…}}`.
 
 | Badge                    | Markdown pattern                                                                                                                         |
 | ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------- |
-| Twitter follow           | `[![X (formerly Twitter) Follow](https://img.shields.io/twitter/follow/{{handle}})](https://twitter.com/{{handle}})`                     |
-| Discord                  | `[![Discord](https://img.shields.io/discord/{{discord-id}}?logo=discord)](https://discord.gg/{{invite-code}})`                           |
+| Twitter follow           | `[![X (formerly Twitter) Follow](https://img.shields.io/twitter/follow/{{twitter-handle}})](https://twitter.com/{{twitter-handle}})`     |
+| Discord                  | `[![Discord](https://img.shields.io/discord/{{discord-id}}?logo=discord)](https://discord.gg/{{discord-invite-code}})`                   |
 | Go version (from go.mod) | `![GitHub go.mod Go version](https://img.shields.io/github/go-mod/go-version/{{repo-path}})`                                             |
 | File count               | `![GitHub repo file or directory count](https://img.shields.io/github/directory-file-count/{{repo-path}})`                               |
 | Code size                | `![GitHub code size in bytes](https://img.shields.io/github/languages/code-size/{{repo-path}})`                                          |
 | CI workflow status       | `![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/{{repo-path}}/{{main-workflow-file}})`          |
 | Go Report Card           | `[![Go Report Card](https://goreportcard.com/badge/github.com/{{repo-path}})](https://goreportcard.com/report/github.com/{{repo-path}})` |
-| Codecov badge            | `[![codecov](https://codecov.io/gh/{{repo-path}}/graph/badge.svg?token={{codecov-graph-token}})](https://codecov.io/gh/{{repo-path}})`   |
-| Codecov sunburst         | `![Coverage graph](https://codecov.io/gh/{{repo-path}}/graphs/sunburst.svg?token={{codecov-graph-token}})`                               |
+| Codecov badge            | Default (no token): `[![codecov](https://codecov.io/gh/{{repo-path}}/graph/badge.svg)](https://codecov.io/gh/{{repo-path}})` — add `?token={{codecov-graph-token}}` to the badge URL only when the repo requires a tokenized variant |
+| Codecov sunburst         | Default (no token): `![Coverage graph](https://codecov.io/gh/{{repo-path}}/graphs/sunburst.svg)` — add `?token={{codecov-graph-token}}` to the image URL only when a tokenized variant is required                                  |
 
 **Codecov graph token — not a secret.** It is the public badge token from
 `codecov.io/gh/<repo>/settings > Badge`. Committing it is intentional. The private upload


### PR DESCRIPTION
## Summary

- Adds three operational skills that codify recurring Claude workflows on this repo: watching CI, pushing + opening PRs, and writing top-level project docs.
- Each skill is self-contained but cross-references the others: `open-pull-request` hands off to `monitor-ci` after a push; both defer to `git-conventions` for commit/branch format; `write-project-docs` explicitly excludes in-source comments (those stay under `document-code`).
- No code is touched — docs only, purely additive.

## Layers changed

- **Skills**: three new `SKILL.md` files under `.claude/skills/{monitor-ci,open-pull-request,write-project-docs}/`.

## Breaking changes

None.

## Test plan

- [ ] CI green (markdown lint + any skill-repo checks)