### PR TITLE
fix(handlers)!: stop leaking dependency errors on gRPC status

### DIFF
--- a/internal/handlers/grpc.status.go
+++ b/internal/handlers/grpc.status.go
@@ -14,19 +14,18 @@ import (
 
 // NewGrpcHealthStatus converts an error into a DependencyHealth proto message,
 // mapping nil to DEPENDENCY_STATUS_UP and any non-nil error to DEPENDENCY_STATUS_DOWN.
+//
+// The error itself is intentionally discarded from the returned message; raw dependency
+// errors routinely embed internal hostnames, ports, or schema names that would leak
+// infrastructure topology. Operators get the underlying error from the trace span the
+// failing health probe records on its way out.
 func NewGrpcHealthStatus(err error) *protogen.DependencyHealth {
-	errMsg := ""
-	if err != nil {
-		errMsg = err.Error()
-	}
-
 	return &protogen.DependencyHealth{
 		Status: lo.Ternary(
 			err == nil,
 			protogen.DependencyStatus_DEPENDENCY_STATUS_UP,
 			protogen.DependencyStatus_DEPENDENCY_STATUS_DOWN,
 		),
-		Err: errMsg,
 	}
 }
 

--- a/internal/handlers/grpc.status_test.go
+++ b/internal/handlers/grpc.status_test.go
@@ -20,6 +20,8 @@ func TestGrpcStatus(t *testing.T) {
 	testCases := []struct {
 		name string
 
+		skipPostgres bool
+
 		expect       *protogen.StatusResponse
 		expectStatus codes.Code
 	}{
@@ -33,6 +35,22 @@ func TestGrpcStatus(t *testing.T) {
 				},
 			},
 		},
+		{
+			// Omitting postgres from the context makes reportPostgres fail, so the
+			// entry reports status=DOWN. The exact-match assertion on expect below
+			// is the regression guard: it fails if any extra field (notably a
+			// re-introduced "err") leaks into the public response shape.
+			name: "Success/Degraded",
+
+			skipPostgres: true,
+
+			expectStatus: codes.OK,
+			expect: &protogen.StatusResponse{
+				Postgres: &protogen.DependencyHealth{
+					Status: protogen.DependencyStatus_DEPENDENCY_STATUS_DOWN,
+				},
+			},
+		},
 	}
 
 	for _, testCase := range testCases {
@@ -41,8 +59,14 @@ func TestGrpcStatus(t *testing.T) {
 
 			handler := handlers.NewGrpcStatus()
 
-			ctx, err := postgres.NewContext(t.Context(), config.PostgresPresetTest)
-			require.NoError(t, err)
+			ctx := t.Context()
+
+			if !testCase.skipPostgres {
+				var err error
+
+				ctx, err = postgres.NewContext(ctx, config.PostgresPresetTest)
+				require.NoError(t, err)
+			}
 
 			res, err := handler.Status(ctx, new(protogen.StatusRequest))
 			resSt, ok := status.FromError(err)

--- a/internal/handlers/protogen/status.pb.go
+++ b/internal/handlers/protogen/status.pb.go
@@ -78,12 +78,16 @@ func (DependencyStatus) EnumDescriptor() ([]byte, []int) {
 }
 
 // DependencyHealth reports the health of a single external dependency.
+//
+// The shape is deliberately minimal. Status endpoints are surfaced over an internal-only
+// gRPC API today, but errors raised while checking dependency health routinely embed
+// internal hostnames, ports, or schema names; carrying them in a public-shaped response
+// would leak infrastructure topology if this surface ever became externally reachable.
+// The underlying error is recorded on the trace span for operators instead.
 type DependencyHealth struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// The dependency's current operational status.
-	Status DependencyStatus `protobuf:"varint,1,opt,name=status,proto3,enum=DependencyStatus" json:"status,omitempty"`
-	// The error that occurred when checking the dependency status, if any.
-	Err           string `protobuf:"bytes,2,opt,name=err,proto3" json:"err,omitempty"`
+	Status        DependencyStatus `protobuf:"varint,1,opt,name=status,proto3,enum=DependencyStatus" json:"status,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -123,13 +127,6 @@ func (x *DependencyHealth) GetStatus() DependencyStatus {
 		return x.Status
 	}
 	return DependencyStatus_DEPENDENCY_STATUS_UNSPECIFIED
-}
-
-func (x *DependencyHealth) GetErr() string {
-	if x != nil {
-		return x.Err
-	}
-	return ""
 }
 
 // StatusRequest carries no parameters; the server checks all dependencies automatically.
@@ -219,10 +216,9 @@ var File_status_proto protoreflect.FileDescriptor
 
 const file_status_proto_rawDesc = "" +
 	"\n" +
-	"\fstatus.proto\"O\n" +
+	"\fstatus.proto\"=\n" +
 	"\x10DependencyHealth\x12)\n" +
-	"\x06status\x18\x01 \x01(\x0e2\x11.DependencyStatusR\x06status\x12\x10\n" +
-	"\x03err\x18\x02 \x01(\tR\x03err\"\x0f\n" +
+	"\x06status\x18\x01 \x01(\x0e2\x11.DependencyStatusR\x06status\"\x0f\n" +
 	"\rStatusRequest\"?\n" +
 	"\x0eStatusResponse\x12-\n" +
 	"\bpostgres\x18\x01 \x01(\v2\x11.DependencyHealthR\bpostgres*k\n" +

--- a/internal/handlers/protogen/status.pb.go
+++ b/internal/handlers/protogen/status.pb.go
@@ -216,9 +216,9 @@ var File_status_proto protoreflect.FileDescriptor
 
 const file_status_proto_rawDesc = "" +
 	"\n" +
-	"\fstatus.proto\"=\n" +
+	"\fstatus.proto\"H\n" +
 	"\x10DependencyHealth\x12)\n" +
-	"\x06status\x18\x01 \x01(\x0e2\x11.DependencyStatusR\x06status\"\x0f\n" +
+	"\x06status\x18\x01 \x01(\x0e2\x11.DependencyStatusR\x06statusJ\x04\b\x02\x10\x03R\x03err\"\x0f\n" +
 	"\rStatusRequest\"?\n" +
 	"\x0eStatusResponse\x12-\n" +
 	"\bpostgres\x18\x01 \x01(\v2\x11.DependencyHealthR\bpostgres*k\n" +

--- a/internal/models/proto/status.proto
+++ b/internal/models/proto/status.proto
@@ -20,11 +20,15 @@ enum DependencyStatus {
 }
 
 // DependencyHealth reports the health of a single external dependency.
+//
+// The shape is deliberately minimal. Status endpoints are surfaced over an internal-only
+// gRPC API today, but errors raised while checking dependency health routinely embed
+// internal hostnames, ports, or schema names; carrying them in a public-shaped response
+// would leak infrastructure topology if this surface ever became externally reachable.
+// The underlying error is recorded on the trace span for operators instead.
 message DependencyHealth {
   // The dependency's current operational status.
   DependencyStatus status = 1;
-  // The error that occurred when checking the dependency status, if any.
-  string err = 2;
 }
 
 // StatusRequest carries no parameters; the server checks all dependencies automatically.

--- a/internal/models/proto/status.proto
+++ b/internal/models/proto/status.proto
@@ -27,6 +27,13 @@ enum DependencyStatus {
 // would leak infrastructure topology if this surface ever became externally reachable.
 // The underlying error is recorded on the trace span for operators instead.
 message DependencyHealth {
+  // Field number 2 / name "err" was used for an error string; it was removed because raw
+  // dependency errors leak infrastructure topology (see message-level comment above). The
+  // number and name are reserved so a future field cannot accidentally re-introduce the leak
+  // with a different shape on the wire.
+  reserved 2;
+  reserved "err";
+
   // The dependency's current operational status.
   DependencyStatus status = 1;
 }


### PR DESCRIPTION
## Summary

- Mirrors PR #532 on the gRPC `StatusService`. The `DependencyHealth` proto message's `err` field is removed so that errors raised while checking dependency health are no longer carried in the response.
- Raw dependency errors routinely embed internal hostnames, ports, or schema names; carrying them in a public-shaped response would leak infrastructure topology if the gRPC surface ever became externally reachable. The underlying error stays available to operators on the trace span the failing health probe records on its way out (`reportPostgres` already calls `otel.ReportError` on the inner span).
- Adds a `Success/Degraded` test case to `grpc.status_test.go` mirroring `rest.health_test.go`. The exact-match assertion on the expected proto fails if any extra field (notably a re-introduced `err`) leaks back into the public response shape.

## Breaking change

`DependencyHealth.err` is removed from `internal/models/proto/status.proto`. The gRPC API is internal-only, so no public consumers should be affected.

## Test plan

- [x] `make format-go` — clean
- [x] `make lint-go` — 0 issues
- [x] `make test-unit` — all 107 tests pass, including the new `TestGrpcStatus/Success/Degraded`
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)