### PR TITLE
chore: align sentinel error handling with documented convention

### DIFF
--- a/internal/dao/pg.jwkDelete.go
+++ b/internal/dao/pg.jwkDelete.go
@@ -19,7 +19,7 @@ import (
 var jwkDeleteQuery string
 
 // ErrJwkDeleteNotFound is returned when no active key matches the delete request.
-var ErrJwkDeleteNotFound = errors.New("key not found")
+var ErrJwkDeleteNotFound = errors.New("jwk not found")
 
 // JwkDeleteRequest holds the parameters for a [PgJwkDelete.Exec] call.
 type JwkDeleteRequest struct {

--- a/internal/handlers/grpc.claimsSign.go
+++ b/internal/handlers/grpc.claimsSign.go
@@ -49,8 +49,6 @@ func (handler *GrpcClaimsSign) ClaimsSign(
 		Usage:  request.GetUsage(),
 	})
 	if errors.Is(err, services.ErrConfigNotFound) {
-		_ = otel.ReportError(span, err)
-
 		return nil, status.Error(codes.Unavailable, "unknown usage")
 	}
 

--- a/internal/handlers/grpc.jwkGet.go
+++ b/internal/handlers/grpc.jwkGet.go
@@ -48,7 +48,7 @@ func (handler *GrpcJwkGet) JwkGet(
 		ID: keyId,
 	})
 	if errors.Is(err, services.ErrJwkNotFound) {
-		return nil, status.Error(codes.NotFound, "key not found")
+		return nil, status.Error(codes.NotFound, "jwk not found")
 	}
 
 	if err != nil {

--- a/internal/services/claimsSign.go
+++ b/internal/services/claimsSign.go
@@ -45,7 +45,7 @@ func (service *ClaimsSign) Exec(ctx context.Context, request *ClaimsSignRequest)
 
 	keyConfig, ok := service.keysConfig[request.Usage]
 	if !ok {
-		return "", otel.ReportError(span, fmt.Errorf("%w: %s", ErrConfigNotFound, request.Usage))
+		return "", fmt.Errorf("%w: %s", ErrConfigNotFound, request.Usage)
 	}
 
 	// Attach the standard JWT claim envelope from the usage config; these claims are
@@ -64,7 +64,7 @@ func (service *ClaimsSign) Exec(ctx context.Context, request *ClaimsSignRequest)
 
 	producerPlugins, ok := service.producers[request.Usage]
 	if !ok {
-		return "", otel.ReportError(span, fmt.Errorf("%w: %s", ErrConfigNotFound, request.Usage))
+		return "", fmt.Errorf("%w: %s", ErrConfigNotFound, request.Usage)
 	}
 
 	producer := jwt.NewProducer(jwt.ProducerConfig{Plugins: producerPlugins})

--- a/internal/services/claimsVerify.go
+++ b/internal/services/claimsVerify.go
@@ -47,7 +47,7 @@ func (service *ClaimsVerify[Out]) Exec(ctx context.Context, request *ClaimsVerif
 
 	keyConfig, ok := service.keysConfig[request.Usage]
 	if !ok {
-		return nil, otel.ReportError(span, fmt.Errorf("%w: %s", ErrConfigNotFound, request.Usage))
+		return nil, fmt.Errorf("%w: %s", ErrConfigNotFound, request.Usage)
 	}
 
 	var claims Out
@@ -70,9 +70,7 @@ func (service *ClaimsVerify[Out]) Exec(ctx context.Context, request *ClaimsVerif
 
 	recipientPlugins, ok := service.recipients[request.Usage]
 	if !ok {
-		return nil, otel.ReportError(span,
-			fmt.Errorf("%w: no recipients found for usage %s", ErrConfigNotFound, request.Usage),
-		)
+		return nil, fmt.Errorf("%w: no recipients found for usage %s", ErrConfigNotFound, request.Usage)
 	}
 
 	recipient := jwt.NewRecipient(

--- a/internal/services/jwkGen.go
+++ b/internal/services/jwkGen.go
@@ -95,7 +95,7 @@ func (service *JwkGen) Exec(ctx context.Context, request *JwkGenRequest) (*Jwk, 
 
 	keyConfig, ok := service.keysConfig[request.Usage]
 	if !ok {
-		return nil, otel.ReportError(span, ErrConfigNotFound)
+		return nil, ErrConfigNotFound
 	}
 
 	span.SetAttributes(


### PR DESCRIPTION
## Summary

Two related drifts from the `write-go-code` skill conventions, fixed together because they all live in the same call chain.

### H3 — `otel.ReportError` on sentinel errors

The skill says: *do not call \`otel.ReportError\` on sentinel errors returned as expected conditions; only report genuine failures*. Six call sites had drifted from that rule, treating \`ErrConfigNotFound\` (and its propagation) as if it were an internal failure:

- \`services/claimsSign.go\` — config and producer lookup misses
- \`services/claimsVerify.go\` — config and recipient lookup misses
- \`services/jwkGen.go\` — config lookup miss
- \`handlers/grpc.claimsSign.go\` — sentinel propagation

Behavior is unchanged for callers; only span attribution differs (these expected-outcome paths no longer record as errors in traces).

### H4 — \"jwk not found\" wording

Every layer of the codebase calls the entity \`Jwk\`. Two error messages had drifted to \`\"key not found\"\`:

- \`dao/pg.jwkDelete.go\` — sentinel error message
- \`handlers/grpc.jwkGet.go\` — gRPC status message

Standardized to \`\"jwk not found\"\` to match \`ErrJwkSelectNotFound\`, \`services.ErrJwkNotFound\`, and the type name itself.

## Test plan

- [x] \`make format-go\` — clean
- [x] \`make lint-go\` — 0 issues
- [x] \`make test-unit\` — all tests pass
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)