### PR TITLE
docs: rewrite README and CONTRIBUTING around audience-first principles

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,211 +1,116 @@
 # Contributing to service-json-keys
 
-Welcome to the JSON Keys service for the A-Novel platform. This guide will help you understand the codebase, set
-up your development environment, and contribute effectively.
+For platform-wide setup (Go, Node, Podman), the standard `make` targets, and lint/test conventions, see the [generic A-Novel contribution guidelines](https://github.com/a-novel/.github/blob/master/CONTRIBUTING.md). This file documents what is specific to the JSON Keys service.
 
-Before reading this guide, if you haven't already, please check the
-[generic contribution guidelines](https://github.com/a-novel/.github/blob/master/CONTRIBUTING.md) that are relevant
-to your scope.
+For deployment, configuration, and client-package integration, read the [README](./README.md) first. Contributors are expected to know what the service does and how operators run it before touching the code.
 
 ---
 
-## Quick Start
+## Quick local interactions
 
-### Prerequisites
+Once `make run` is up, the gRPC server listens on `${SERVICE_JSON_KEYS_GRPC_PORT}` and the REST server on `${SERVICE_JSON_KEYS_REST_PORT}`.
 
-The following must be installed on your system.
-
-- [Go](https://go.dev/doc/install)
-- [Node.js](https://nodejs.org/en/download)
-  - [pnpm](https://pnpm.io/installation)
-- [Podman](https://podman.io/docs/installation)
-- (optional) [Direnv](https://direnv.net/)
-- Make
-  - `sudo apt-get install build-essential` (apt)
-  - `sudo pacman -S make` (arch)
-  - `brew install make` (macOS)
-  - [Make for Windows](https://gnuwin32.sourceforge.net/packages/make.htm)
-
-### Bootstrap
-
-Install the dependencies:
+### Health
 
 ```bash
-make install
-```
-
-### Common Commands
-
-| Command         | Description                      |
-| --------------- | -------------------------------- |
-| `make run`      | Start all services locally       |
-| `make test`     | Run all tests                    |
-| `make lint`     | Run all linters                  |
-| `make format`   | Format all code                  |
-| `make build`    | Build Docker images locally      |
-| `make generate` | Generate mocks and protobuf code |
-
-### Interacting with the Service
-
-Once the service is running (`make run`), you can interact with it using:
-
-- `curl` or any HTTP client (REST API).
-- `grpcurl` or any gRPC client (gRPC API).
-
-#### Health Checks
-
-```bash
-# REST: Simple ping (is the server up?)
+# REST: liveness
 curl http://localhost:${SERVICE_JSON_KEYS_REST_PORT}/ping
 
-# REST: Detailed health check (checks database, dependencies)
+# REST: dependency check (Postgres ping)
 curl http://localhost:${SERVICE_JSON_KEYS_REST_PORT}/healthcheck
 
-# gRPC: Simple ping (is the server up?)
-grpcurl -plaintext localhost:${SERVICE_JSON_KEYS_GRPC_PORT} grpc.health.v1.Health/Check
-
-# gRPC: Check the status of all services.
+# gRPC: dependency check
 grpcurl -plaintext localhost:${SERVICE_JSON_KEYS_GRPC_PORT} StatusService/Status
 ```
 
-#### Key Operations
-
-List available keys:
+### Reading keys
 
 ```bash
-# REST
+# REST: list active public keys for a usage
 curl "http://localhost:${SERVICE_JSON_KEYS_REST_PORT}/jwks?usage=auth"
 
-# gRPC
-grpcurl -plaintext -d '{"usage": "auth"}' "localhost:${SERVICE_JSON_KEYS_GRPC_PORT}" JwkListService/JwkList
-```
-
-Get a specific key:
-
-```bash
-# REST
+# REST: fetch a single public key by ID
 curl "http://localhost:${SERVICE_JSON_KEYS_REST_PORT}/jwk?id=<key-uuid>"
 
-# gRPC
-grpcurl -plaintext -d '{"id": "<key-uuid>"}' "localhost:${SERVICE_JSON_KEYS_GRPC_PORT}" JwkGetService/JwkGet
+# gRPC: same operations through the private surface
+grpcurl -plaintext -d '{"usage":"auth"}' localhost:${SERVICE_JSON_KEYS_GRPC_PORT} JwkListService/JwkList
+grpcurl -plaintext -d '{"id":"<key-uuid>"}' localhost:${SERVICE_JSON_KEYS_GRPC_PORT} JwkGetService/JwkGet
+```
+
+### Signing claims (gRPC only)
+
+Signing requires the master key (`APP_MASTER_KEY`) and is only exposed over the private gRPC surface.
+
+```bash
+grpcurl -plaintext \
+  -d '{"usage":"auth","payload":{"@type":"type.googleapis.com/google.protobuf.Struct","value":{"userID":"user-1"}}}' \
+  localhost:${SERVICE_JSON_KEYS_GRPC_PORT} \
+  ClaimsSignService/ClaimsSign
 ```
 
 ---
 
-## Project-Specific Guidelines
+## Service-specific concepts
 
-> This section contains patterns specific to this JSON Keys service.
+### Master key encryption
 
-### Master Key Encryption
+Private JWKs are stored encrypted with the application **master key**. The implementation lives in [`internal/lib/masterKeyCrypt.go`](./internal/lib/masterKeyCrypt.go) and uses [NaCl secretbox](https://nacl.cr.yp.to/secretbox.html) — XSalsa20-Poly1305 authenticated encryption with a per-message random 24-byte nonce prepended to the ciphertext.
 
-Private JWKs are stored encrypted using AES-GCM with a master key. The master key is:
+The master key is loaded from the `APP_MASTER_KEY` env var as a hex-encoded 32-byte secret, parsed by `lib.NewMasterKeyContext`, and pulled out via `lib.MasterKeyContext` on every read or write of a private key payload.
 
-- Loaded from `APP_MASTER_KEY` environment variable
-- Stored in context via `lib.NewMasterKeyContext()`
-- Used to encrypt/decrypt private key payloads before storage/retrieval
+> **Rotating `APP_MASTER_KEY` permanently invalidates every existing private key.** New keys can be re-issued via the rotation job, but legacy keys encrypted under the old master key cannot be decrypted by the new one. This is why the README warns operators not to rotate it.
 
-**Critical:** The master key should **never** be rotated unless absolutely necessary — changing it will permanently lose access to all existing encrypted keys.
+### JWK lifecycle and the active view
 
-### JWK Lifecycle
+Each usage has at most one **main** key (the latest by `created_at`) and zero or more **legacy** keys (older versions still within their TTL). Producers sign only with the main key; recipients accept tokens signed by any active key for the usage, so a rolling rotation is non-disruptive for token consumers.
 
-Keys go through the following states:
+The `keys` table — defined in [`internal/models/migrations/`](./internal/models/migrations/) and modelled by `dao.Jwk` in [`internal/dao/pg.jwk.go`](./internal/dao/pg.jwk.go) — records:
 
-1. **Generated**: New key created with expiration time
-2. **Active**: Key is used for signing
-3. **Expired**: Key past expiration, still valid for verification
-4. **Deleted**: Key removed from database
+| Column                          | Meaning                                                            |
+| ------------------------------- | ------------------------------------------------------------------ |
+| `created_at`                    | When the key was generated.                                        |
+| `expires_at`                    | Hard expiry; the key leaves the active view at this point.         |
+| `deleted_at`, `deleted_comment` | Premature revocation (e.g., compromise). `nil` for natural expiry. |
 
-### Key Configuration
+Reads target the `active_keys` materialized view, which excludes expired and soft-deleted rows. The view is refreshed by the rotation job after a write so consumers see the new main key on their next fetch.
 
-Key types and their settings are defined in `internal/config/jwks.config.yaml`:
+### Key configuration
+
+The per-usage configuration ships in [`internal/config/jwks.config.yaml`](./internal/config/jwks.config.yaml). Each top-level key is a usage name; the schema below matches `config.Jwk` in [`internal/config/jwks.config.go`](./internal/config/jwks.config.go):
 
 ```yaml
 auth:
-  algorithm: ES256
-  rotation: 720h
-  expiry: 8760h
+  alg: EdDSA # signing algorithm: HS256/384/512, ES256/384/512, RS256/384/512, PS256/384/512, EdDSA
+  key:
+    ttl: 168h # how long a key version stays active before expiring
+    rotation: 24h # cadence at which a new key is generated; should be << ttl
+    cache: 30m # how long consumers cache fetched public keys before re-fetching
+  token:
+    ttl: 24h # how long a signed token is valid
+    issuer: "..." # JWT iss claim
+    audience: "..." # JWT aud claim
+    subject: "..." # JWT sub claim
+    leeway: 5m # clock-skew tolerance when validating expiry
 ```
 
-Each key usage (e.g., `auth`) can have different algorithms, rotation schedules, and expiry times.
+Adding a usage requires the same entry in every consumer that uses `pkg/go` — the `KeyUsageAuth`-style constants pin the usage by name, but the consumer also needs to know its config to wire the matching verifier.
 
-### Key Rotation
+### Key rotation
 
-The `rotate-keys` job (`cmd/rotate-keys/main.go`) handles automatic key rotation:
+[`cmd/rotate-keys/main.go`](./cmd/rotate-keys/main.go) is a one-shot job. For each configured usage, it generates a new key when the current main key is older than `key.rotation`, then refreshes the `active_keys` materialized view so consumers see the change immediately. Run it on a schedule (cron, Kubernetes CronJob, etc.). Without it, keys still rotate by TTL — the job just keeps the rotation cadence tight.
 
-- Generates new keys when current ones approach expiration
-- Deletes keys past their retention period
-- Should be run as a scheduled job (cron, Kubernetes CronJob, etc.)
+### Surfaces
 
-### gRPC Services
+| Surface           | Audience                | Operations                                                              | Spec                                                 |
+| ----------------- | ----------------------- | ----------------------------------------------------------------------- | ---------------------------------------------------- |
+| gRPC (`cmd/grpc`) | Internal, authenticated | `StatusService`, `JwkGetService`, `JwkListService`, `ClaimsSignService` | [`internal/models/proto/`](./internal/models/proto/) |
+| REST (`cmd/rest`) | Public, unauthenticated | `/ping`, `/healthcheck`, `/jwks`, `/jwk`                                | [`openapi.yaml`](./openapi.yaml)                     |
 
-| Service             | Purpose                    |
-| ------------------- | -------------------------- |
-| `StatusService`     | Health and status checks   |
-| `JwkGetService`     | Retrieve single key by ID  |
-| `JwkListService`    | List keys by usage         |
-| `ClaimsSignService` | Sign JWT claims with a key |
-
-### REST API
-
-The REST API serves public JWK data over HTTP. It is documented via an OpenAPI spec:
-
-- `openapi.yaml` — machine-readable spec
-- `openapi.html` — interactive Scalar API Reference viewer (open in a browser)
-
-The published API reference is hosted at [GitHub Pages](https://a-novel.github.io/service-json-keys-v2).
-
-### JavaScript Client Package
-
-Frontend or Node.js consumers can use `@a-novel/service-json-keys-rest` (`pkg/js/rest/`) to call the REST API:
-
-```typescript
-import { JsonKeysApi, jwkGet, jwkList } from "@a-novel/service-json-keys-rest";
-
-const api = new JsonKeysApi("http://localhost:4021");
-
-// Check service health.
-await api.ping();
-
-// Fetch public keys.
-const keys = await jwkList(api, "auth");
-const key = await jwkGet(api, "<key-id>");
-```
-
-Integration tests for the JS client live in `pkg/js/test/rest/`. Run them locally with:
-
-```bash
-make test-pkg-js
-```
-
-### Go Client Package
-
-Other services integrate with json-keys via the `pkg/` package:
-
-```go
-import jkpkg "github.com/a-novel/service-json-keys/v2/pkg/go"
-
-// Create client
-client, err := jkpkg.NewClient("<grpc-address>")
-
-// Sign claims
-token, err := client.ClaimsSign(ctx, &jkpkg.ClaimsSignRequest{
-    Usage:   "auth",
-    Payload: claimsPayload,
-})
-
-// Verify claims
-verifier := jkpkg.NewClaimsVerifier[MyClaims](client)
-claims, err := verifier.VerifyClaims(ctx, &jkpkg.VerifyClaimsRequest{
-    Usage:       "auth",
-    AccessToken: token.GetToken(),
-})
-```
+The REST surface never exposes private keys or signing operations. The split is enforced structurally by registering the signing handler only inside [`cmd/grpc/main.go`](./cmd/grpc/main.go).
 
 ---
 
 ## Questions?
-
-If you have questions or run into issues:
 
 - Open an issue at https://github.com/a-novel/service-json-keys/issues
 - Check existing issues for similar problems

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,33 +8,33 @@ For deployment, configuration, and client-package integration, read the [README]
 
 ## Quick local interactions
 
-Once `make run` is up, the gRPC server listens on `${SERVICE_JSON_KEYS_GRPC_PORT}` and the REST server on `${SERVICE_JSON_KEYS_REST_PORT}`.
+Once `make run` is up, the gRPC server listens on `${GRPC_PORT}` and the REST server on `${REST_PORT}`.
 
 ### Health
 
 ```bash
 # REST: liveness
-curl http://localhost:${SERVICE_JSON_KEYS_REST_PORT}/ping
+curl http://localhost:${REST_PORT}/ping
 
 # REST: dependency check (Postgres ping)
-curl http://localhost:${SERVICE_JSON_KEYS_REST_PORT}/healthcheck
+curl http://localhost:${REST_PORT}/healthcheck
 
 # gRPC: dependency check
-grpcurl -plaintext localhost:${SERVICE_JSON_KEYS_GRPC_PORT} StatusService/Status
+grpcurl -plaintext localhost:${GRPC_PORT} StatusService/Status
 ```
 
 ### Reading keys
 
 ```bash
 # REST: list active public keys for a usage
-curl "http://localhost:${SERVICE_JSON_KEYS_REST_PORT}/jwks?usage=auth"
+curl "http://localhost:${REST_PORT}/jwks?usage=auth"
 
 # REST: fetch a single public key by ID
-curl "http://localhost:${SERVICE_JSON_KEYS_REST_PORT}/jwk?id=<key-uuid>"
+curl "http://localhost:${REST_PORT}/jwk?id=<key-uuid>"
 
 # gRPC: same operations through the private surface
-grpcurl -plaintext -d '{"usage":"auth"}' localhost:${SERVICE_JSON_KEYS_GRPC_PORT} JwkListService/JwkList
-grpcurl -plaintext -d '{"id":"<key-uuid>"}' localhost:${SERVICE_JSON_KEYS_GRPC_PORT} JwkGetService/JwkGet
+grpcurl -plaintext -d '{"usage":"auth"}' localhost:${GRPC_PORT} JwkListService/JwkList
+grpcurl -plaintext -d '{"id":"<key-uuid>"}' localhost:${GRPC_PORT} JwkGetService/JwkGet
 ```
 
 ### Signing claims (gRPC only)
@@ -44,7 +44,7 @@ Signing requires the master key (`APP_MASTER_KEY`) and is only exposed over the 
 ```bash
 grpcurl -plaintext \
   -d '{"usage":"auth","payload":{"@type":"type.googleapis.com/google.protobuf.Struct","value":{"userID":"user-1"}}}' \
-  localhost:${SERVICE_JSON_KEYS_GRPC_PORT} \
+  localhost:${GRPC_PORT} \
   ClaimsSignService/ClaimsSign
 ```
 
@@ -101,12 +101,12 @@ Adding a usage requires the same entry in every consumer that uses `pkg/go` — 
 
 ### Surfaces
 
-| Surface           | Audience                | Operations                                                              | Spec                                                 |
-| ----------------- | ----------------------- | ----------------------------------------------------------------------- | ---------------------------------------------------- |
-| gRPC (`cmd/grpc`) | Internal, authenticated | `StatusService`, `JwkGetService`, `JwkListService`, `ClaimsSignService` | [`internal/models/proto/`](./internal/models/proto/) |
-| REST (`cmd/rest`) | Public, unauthenticated | `/ping`, `/healthcheck`, `/jwks`, `/jwk`                                | [`openapi.yaml`](./openapi.yaml)                     |
+| Surface           | Audience                       | Operations                                                              | Spec                                                 |
+| ----------------- | ------------------------------ | ----------------------------------------------------------------------- | ---------------------------------------------------- |
+| gRPC (`cmd/grpc`) | Internal, private network only | `StatusService`, `JwkGetService`, `JwkListService`, `ClaimsSignService` | [`internal/models/proto/`](./internal/models/proto/) |
+| REST (`cmd/rest`) | Public, unauthenticated        | `/ping`, `/healthcheck`, `/jwks`, `/jwk`                                | [`openapi.yaml`](./openapi.yaml)                     |
 
-The REST surface never exposes private keys or signing operations. The split is enforced structurally by registering the signing handler only inside [`cmd/grpc/main.go`](./cmd/grpc/main.go).
+The REST surface never exposes private keys or signing operations. The split is enforced structurally by registering the signing handler only inside [`cmd/grpc/main.go`](./cmd/grpc/main.go). The gRPC server itself implements no application-layer authentication — access control on that surface is enforced entirely by deployment infrastructure (network policy, ingress, service mesh).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -15,22 +15,28 @@
 
 ![Coverage graph](https://codecov.io/gh/a-novel/service-json-keys/graphs/sunburst.svg?token=almKepuGQE)
 
-## Usage
+## What it does
 
-### Docker
+JSON Keys is a centralized signing-key manager for the A-Novel platform. Services register named **usages** (`auth`, `auth-refresh`, etc.); each usage has its own signing algorithm, rotation schedule, and JWT claim parameters. The service holds every private key and signs tokens on behalf of callers — private key material never leaves the server. Consumers fetch the matching public keys through a read-only REST endpoint and verify tokens locally, with no extra network round-trip per token.
 
-Run the service as a containerized application (the below examples use docker-compose syntax).
+The service ships two surfaces:
 
-#### gRPC
+- A **private gRPC API** (signing, key retrieval, status) for authenticated service-to-service traffic. Anything that touches private key material lives here.
+- A **public REST API** (public-key fetch, health) for any client that needs to verify tokens.
 
-> Set the SERVICE_JSON_KEYS_GRPC_PORT env variable to whatever port you want to use for the service.
+State lives in a PostgreSQL database; both surfaces are stateless and can run as multiple replicas behind a load balancer.
+
+## Running it
+
+The minimal local setup is one Postgres image plus one service image. Pin both to the same release tag (current: `v2.2.6`).
+
+The example below runs the gRPC server in **standalone** mode — the simplest path to a working signing API. Set `SERVICE_JSON_KEYS_GRPC_PORT` to whichever port you want to expose.
 
 ```yaml
 services:
   postgres-json-keys:
     image: ghcr.io/a-novel/service-json-keys/database:v2.2.6
-    networks:
-      - api
+    networks: [api]
     environment:
       POSTGRES_PASSWORD: postgres
       POSTGRES_USER: postgres
@@ -42,16 +48,13 @@ services:
 
   service-json-keys:
     image: ghcr.io/a-novel/service-json-keys/standalone-grpc:v2.2.6
-    ports:
-      - "${SERVICE_JSON_KEYS_GRPC_PORT}:8080"
+    ports: ["${SERVICE_JSON_KEYS_GRPC_PORT}:8080"]
     depends_on:
-      postgres-json-keys:
-        condition: service_healthy
+      postgres-json-keys: { condition: service_healthy }
     environment:
       POSTGRES_DSN: "postgres://postgres:postgres@postgres-json-keys:5432/postgres?sslmode=disable"
       APP_MASTER_KEY: "<your-master-key-here>"
-    networks:
-      - api
+    networks: [api]
 
 networks:
   api:
@@ -60,16 +63,25 @@ volumes:
   json-keys-postgres-data:
 ```
 
-Note the standalone image is an all-in-one initializer for the application; however, it runs heavy operations such
-as migrations on every launch. Thus, while it comes in handy for local development, it is NOT RECOMMENDED for
-production deployments. Instead, consider using the separate, optimized images for that purpose.
+The four deployment shapes:
+
+| Shape           | When to use                       | Image                                                 |
+| --------------- | --------------------------------- | ----------------------------------------------------- |
+| Standalone gRPC | Local dev, signing experiments    | `service-json-keys/standalone-grpc`                   |
+| Standalone REST | Local dev, public-key access only | `service-json-keys/standalone-rest`                   |
+| gRPC            | Production gRPC tier              | `service-json-keys/grpc` (+ `migrations`, `database`) |
+| REST            | Production REST tier              | `service-json-keys/rest` (+ `migrations`, `database`) |
+
+> Standalone images run migrations on every startup. Convenient for development but unsuitable for production — every replica restart re-runs the migration job. For production, use the split images plus the dedicated `migrations` image.
+
+<details>
+<summary>Production-shape example (split gRPC)</summary>
 
 ```yaml
 services:
   postgres-json-keys:
     image: ghcr.io/a-novel/service-json-keys/database:v2.2.6
-    networks:
-      - api
+    networks: [api]
     environment:
       POSTGRES_PASSWORD: postgres
       POSTGRES_USER: postgres
@@ -82,27 +94,21 @@ services:
   migrations-json-keys:
     image: ghcr.io/a-novel/service-json-keys/migrations:v2.2.6
     depends_on:
-      postgres-json-keys:
-        condition: service_healthy
+      postgres-json-keys: { condition: service_healthy }
     environment:
       POSTGRES_DSN: "postgres://postgres:postgres@postgres-json-keys:5432/postgres?sslmode=disable"
-    networks:
-      - api
+    networks: [api]
 
   service-json-keys:
     image: ghcr.io/a-novel/service-json-keys/grpc:v2.2.6
-    ports:
-      - "${SERVICE_JSON_KEYS_GRPC_PORT}:8080"
+    ports: ["${SERVICE_JSON_KEYS_GRPC_PORT}:8080"]
     depends_on:
-      postgres-json-keys:
-        condition: service_healthy
-      migrations-json-keys:
-        condition: service_completed_successfully
+      postgres-json-keys: { condition: service_healthy }
+      migrations-json-keys: { condition: service_completed_successfully }
     environment:
       POSTGRES_DSN: "postgres://postgres:postgres@postgres-json-keys:5432/postgres?sslmode=disable"
       APP_MASTER_KEY: "<your-master-key-here>"
-    networks:
-      - api
+    networks: [api]
 
 networks:
   api:
@@ -111,146 +117,121 @@ volumes:
   json-keys-postgres-data:
 ```
 
-#### REST
+The REST equivalent uses `service-json-keys/rest:v2.2.6` instead of `grpc:v2.2.6`.
 
-> Set the SERVICE_JSON_KEYS_REST_PORT env variable to whatever port you want to use for the service.
+</details>
 
-```yaml
-services:
-  postgres-json-keys:
-    image: ghcr.io/a-novel/service-json-keys/database:v2.2.6
-    networks:
-      - api
-    environment:
-      POSTGRES_PASSWORD: postgres
-      POSTGRES_USER: postgres
-      POSTGRES_DB: postgres
-      POSTGRES_HOST_AUTH_METHOD: scram-sha-256
-      POSTGRES_INITDB_ARGS: --auth=scram-sha-256
-    volumes:
-      - json-keys-postgres-data:/var/lib/postgresql/
+### Configuration
 
-  service-json-keys:
-    image: ghcr.io/a-novel/service-json-keys/standalone-rest:v2.2.6
-    ports:
-      - "${SERVICE_JSON_KEYS_REST_PORT}:8080"
-    depends_on:
-      postgres-json-keys:
-        condition: service_healthy
-    environment:
-      POSTGRES_DSN: "postgres://postgres:postgres@postgres-json-keys:5432/postgres?sslmode=disable"
-      APP_MASTER_KEY: "<your-master-key-here>"
-    networks:
-      - api
+Configuration is driven by environment variables.
 
-networks:
-  api:
+**Required**
 
-volumes:
-  json-keys-postgres-data:
+| Name             | Description                                                                                                                                                                                                         | Images                                                                         |
+| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
+| `POSTGRES_DSN`   | PostgreSQL connection string.                                                                                                                                                                                       | `standalone-grpc`<br/>`standalone-rest`<br/>`grpc`<br/>`rest`<br/>`migrations` |
+| `APP_MASTER_KEY` | 32-byte hex-encoded master key used to encrypt private keys at rest. **Never rotate** unless you can afford to invalidate every existing private key — see [CONTRIBUTING](./CONTRIBUTING.md#master-key-encryption). | `standalone-grpc`<br/>`standalone-rest`<br/>`grpc`<br/>`rest`                  |
+
+The gRPC surface exposes private-key operations and must run on an isolated, authenticated network.
+
+**Optional — REST tuning**
+
+| Name                          | Description                          | Default          | Images                       |
+| ----------------------------- | ------------------------------------ | ---------------- | ---------------------------- |
+| `REST_MAX_REQUEST_SIZE`       | Maximum request body size, in bytes. | `2097152` (2MiB) | `standalone-rest`<br/>`rest` |
+| `REST_TIMEOUT_READ`           | Read timeout.                        | `15s`            | `standalone-rest`<br/>`rest` |
+| `REST_TIMEOUT_READ_HEADER`    | Header read timeout.                 | `3s`             | `standalone-rest`<br/>`rest` |
+| `REST_TIMEOUT_WRITE`          | Write timeout.                       | `30s`            | `standalone-rest`<br/>`rest` |
+| `REST_TIMEOUT_IDLE`           | Idle keep-alive timeout.             | `60s`            | `standalone-rest`<br/>`rest` |
+| `REST_TIMEOUT_REQUEST`        | Per-request timeout.                 | `60s`            | `standalone-rest`<br/>`rest` |
+| `REST_CORS_ALLOWED_ORIGINS`   | CORS allowed origins.                | `*`              | `standalone-rest`<br/>`rest` |
+| `REST_CORS_ALLOWED_HEADERS`   | CORS allowed headers.                | `*`              | `standalone-rest`<br/>`rest` |
+| `REST_CORS_ALLOW_CREDENTIALS` | CORS allow-credentials flag.         | `false`          | `standalone-rest`<br/>`rest` |
+| `REST_CORS_MAX_AGE`           | CORS max-age (seconds).              | `3600`           | `standalone-rest`<br/>`rest` |
+
+**Optional — Logs and tracing**
+
+OpenTelemetry currently supports two exporters: stdout and Google Cloud.
+
+| Name                | Description                                                                    | Default             | Images                                                        |
+| ------------------- | ------------------------------------------------------------------------------ | ------------------- | ------------------------------------------------------------- |
+| `OTEL`              | Enable OTel tracing. Use the variables below to pick the exporter.             | `false`             | `standalone-grpc`<br/>`standalone-rest`<br/>`grpc`<br/>`rest` |
+| `GCLOUD_PROJECT_ID` | Google Cloud project ID. When set, switches the OTel exporter to Google Cloud. |                     | `standalone-grpc`<br/>`standalone-rest`<br/>`grpc`<br/>`rest` |
+| `APP_NAME`          | Application name attached to traces and logs.                                  | `service-json-keys` | `standalone-grpc`<br/>`standalone-rest`<br/>`grpc`<br/>`rest` |
+
+## Using the client packages
+
+Two client packages ship with this service:
+
+- **Go** — talks gRPC. Use this from a backend service that needs to sign tokens or verify them with cached public keys.
+- **JavaScript / TypeScript** — talks REST. Use this from a frontend or Node service that only needs public keys for local verification.
+
+Each example below is the **minimum viable call**. The full surface is what your editor's intellisense, [pkg.go.dev](https://pkg.go.dev/github.com/a-novel/service-json-keys/v2), and the [API reference](https://a-novel.github.io/service-json-keys-v2) are for.
+
+### Go (gRPC)
+
+```bash
+go get github.com/a-novel/service-json-keys/v2
 ```
 
-Note the standalone image is an all-in-one initializer for the application; however, it runs heavy operations such
-as migrations on every launch. Thus, while it comes in handy for local development, it is NOT RECOMMENDED for
-production deployments. Instead, consider using the separate, optimized images for that purpose.
+```go
+package main
 
-```yaml
-services:
-  postgres-json-keys:
-    image: ghcr.io/a-novel/service-json-keys/database:v2.2.6
-    networks:
-      - api
-    environment:
-      POSTGRES_PASSWORD: postgres
-      POSTGRES_USER: postgres
-      POSTGRES_DB: postgres
-      POSTGRES_HOST_AUTH_METHOD: scram-sha-256
-      POSTGRES_INITDB_ARGS: --auth=scram-sha-256
-    volumes:
-      - json-keys-postgres-data:/var/lib/postgresql/
+import (
+	"context"
+	"log"
 
-  migrations-json-keys:
-    image: ghcr.io/a-novel/service-json-keys/migrations:v2.2.6
-    depends_on:
-      postgres-json-keys:
-        condition: service_healthy
-    environment:
-      POSTGRES_DSN: "postgres://postgres:postgres@postgres-json-keys:5432/postgres?sslmode=disable"
-    networks:
-      - api
+	"github.com/a-novel-kit/golib/grpcf"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 
-  service-json-keys:
-    image: ghcr.io/a-novel/service-json-keys/rest:v2.2.6
-    ports:
-      - "${SERVICE_JSON_KEYS_REST_PORT}:8080"
-    depends_on:
-      postgres-json-keys:
-        condition: service_healthy
-      migrations-json-keys:
-        condition: service_completed_successfully
-    environment:
-      POSTGRES_DSN: "postgres://postgres:postgres@postgres-json-keys:5432/postgres?sslmode=disable"
-      APP_MASTER_KEY: "<your-master-key-here>"
-    networks:
-      - api
+	servicejsonkeys "github.com/a-novel/service-json-keys/v2/pkg/go"
+)
 
-networks:
-  api:
+type MyClaims struct {
+	UserID string `json:"userID"`
+}
 
-volumes:
-  json-keys-postgres-data:
+func main() {
+	ctx := context.Background()
+
+	client, err := servicejsonkeys.NewClient(
+		"service-json-keys:8080",
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer client.Close()
+
+	// Sign claims under the auth usage.
+	payload, _ := grpcf.InterfaceToProtoAny(MyClaims{UserID: "user-1"})
+	res, err := client.ClaimsSign(ctx, &servicejsonkeys.ClaimsSignRequest{
+		Usage:   servicejsonkeys.KeyUsageAuth,
+		Payload: payload,
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Verify locally — no extra network call per token.
+	verifier := servicejsonkeys.NewClaimsVerifier[MyClaims](client)
+	claims, err := verifier.VerifyClaims(ctx, &servicejsonkeys.VerifyClaimsRequest{
+		Usage:       servicejsonkeys.KeyUsageAuth,
+		AccessToken: res.GetToken(),
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+	_ = claims // claims.UserID == "user-1"
+}
 ```
 
-Above are the minimal required configuration to run the service locally. Configuration is done through environment
-variables. Below is a list of available configurations:
+### JavaScript / TypeScript (REST)
 
-**Required variables**
+The package is published to GitHub Packages. GitHub requires a Personal Access Token with `repo` and `read:packages` scopes to install from there, even for public packages — see [this discussion](https://github.com/orgs/community/discussions/23386#discussioncomment-3240193).
 
-| Name           | Description                                                                                                                                                                                            | Images                                                                         |
-| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------ |
-| POSTGRES_DSN   | The Postgres Data Source Name (DSN) used to connect to the database.                                                                                                                                   | `standalone-grpc`<br/>`standalone-rest`<br/>`grpc`<br/>`rest`<br/>`migrations` |
-| APP_MASTER_KEY | Master key used to securely encrypt private keys in the database. This should NEVER be exposed, and should not be rotated unless necessary (changing it will lose access to previous keys permanently) | `standalone-grpc`<br/>`standalone-rest`<br/>`grpc`<br/>`rest`                  |
-
-The gRPC service exposes sensitive data, and should run in an isolated, secure network.
-
-**REST API**
-
-While you should not need to change these values in most cases, the following variables allow you to
-customize the REST API behavior.
-
-| Name                        | Description                                 | Default value    | Images                       |
-| --------------------------- | ------------------------------------------- | ---------------- | ---------------------------- |
-| REST_MAX_REQUEST_SIZE       | Maximum size of incoming requests in bytes  | `2097152` (2MiB) | `standalone-rest`<br/>`rest` |
-| REST_TIMEOUT_READ           | Timeout for read operations                 | `15s`            | `standalone-rest`<br/>`rest` |
-| REST_TIMEOUT_READ_HEADER    | Timeout for header reading operations       | `3s`             | `standalone-rest`<br/>`rest` |
-| REST_TIMEOUT_WRITE          | Timeout for write operations                | `30s`            | `standalone-rest`<br/>`rest` |
-| REST_TIMEOUT_IDLE           | Idle timeout                                | `60s`            | `standalone-rest`<br/>`rest` |
-| REST_TIMEOUT_REQUEST        | Timeout for api requests                    | `60s`            | `standalone-rest`<br/>`rest` |
-| REST_CORS_ALLOWED_ORIGINS   | CORS allowed origins (allow all by default) | `*`              | `standalone-rest`<br/>`rest` |
-| REST_CORS_ALLOWED_HEADERS   | CORS allowed headers (allow all by default) | `*`              | `standalone-rest`<br/>`rest` |
-| REST_CORS_ALLOW_CREDENTIALS | CORS allow credentials                      | `false`          | `standalone-rest`<br/>`rest` |
-| REST_CORS_MAX_AGE           | CORS max age                                | `3600`           | `standalone-rest`<br/>`rest` |
-
-**Logs & Tracing**
-
-For now, OTEL is only provided using 2 exporters: stdout and Google Cloud. Other integrations may come
-in the future.
-
-| Name              | Description                                                                             | Default value       | Images                                                        |
-| ----------------- | --------------------------------------------------------------------------------------- | ------------------- | ------------------------------------------------------------- |
-| OTEL              | Activate OTEL tracing (use options below to switch between exporters)                   | `false`             | `standalone-grpc`<br/>`standalone-rest`<br/>`grpc`<br/>`rest` |
-| GCLOUD_PROJECT_ID | Google Cloud project id for the OTEL exporter. Switch to Google Cloud exporter when set |                     | `standalone-grpc`<br/>`standalone-rest`<br/>`grpc`<br/>`rest` |
-| APP_NAME          | Application name to be used in traces                                                   | `service-json-keys` | `standalone-grpc`<br/>`standalone-rest`<br/>`grpc`<br/>`rest` |
-
-### Javascript (npm)
-
-To interact with a running REST instance of the JSON Keys service, you can use the integrated package.
-
-> ⚠️ **Warning**: Even though the package is public, GitHub registry requires you to have a Personal Access Token
-> with `repo` and `read:packages` scopes to pull it in your project. See
-> [this issue](https://github.com/orgs/community/discussions/23386#discussioncomment-3240193) for more information.
-
-Make sure you have a `.npmrc` with the following content (in your project or in your home directory):
+Add to `.npmrc` (project root or `$HOME`):
 
 ```ini
 @a-novel:registry=https://npm.pkg.github.com
@@ -258,82 +239,19 @@ Make sure you have a `.npmrc` with the following content (in your project or in 
 //npm.pkg.github.com/:_authToken=${YOUR_PERSONAL_ACCESS_TOKEN}
 ```
 
-Then, install the package using pnpm:
+Install and use:
 
 ```bash
-# pnpm config set auto-install-peers true
-#  Or
-# pnpm config set auto-install-peers true --location project
 pnpm add @a-novel/service-json-keys-rest
 ```
 
-To use it, create a `JsonKeysApi` instance. A single instance can be shared across your client.
-
 ```typescript
-import { JsonKeysApi, jwkGet, jwkList } from "@a-novel/service-json-keys-rest";
+import { JsonKeysApi, jwkList } from "@a-novel/service-json-keys-rest";
 
-export const jsonKeysApi = new JsonKeysApi("<base_api_url>");
+const api = new JsonKeysApi("http://service-json-keys:8080");
 
-// (optional) check the status of the api connection.
-await jsonKeysApi.ping();
-await jsonKeysApi.health();
+// Fetch the active public keys for a usage; cache them client-side and verify locally.
+const keys = await jwkList(api, "auth");
 ```
 
-Retrieve JWK keys:
-
-```typescript
-// List all keys for a given usage.
-const keys = await jwkList(jsonKeysApi, "auth");
-
-// Retrieve a specific key by ID.
-const key = await jwkGet(jsonKeysApi, "<key-id>");
-```
-
-The API reference is available at [GitHub Pages](https://a-novel.github.io/service-json-keys-v2).
-
-### Go module
-
-You can integrate the json keys capabilities directly into your Go services by using the provided
-Go module. It requires a connection to a running instance of this service.
-
-```bash
-go get -u github.com/a-novel/service-json-keys/v2
-```
-
-```go
-package main
-
-import (
-  "context"
-
-  "github.com/a-novel-kit/golib/grpcf"
-  "github.com/a-novel/service-json-keys/v2/pkg/go"
-)
-
-type MyClaims struct {
-  UserID string `json:"userID"`
-}
-
-func main() {
-  ctx := context.Background()
-
-  client, _ := servicejsonkeys.NewClient(ctx, "<service-json-keys-url>")
-  claimsVerifier := servicejsonkeys.NewClaimsVerifier[MyClaims](client)
-
-  claims := MyClaims{ UserID: "user-1" }
-  claimsPayload, _ := grpcf.InterfaceToProtoAny(claims)
-
-  // Signed token ready for use.
-  token, _ := client.ClaimsSign(ctx, &servicejsonkeys.ClaimsSignRequest{
-    Usage: servicejsonkeys.KeyUsageAuth,
-    Payload: claimsPayload,
-  })
-
-  decodedClaims, _ := claimsVerifier.VerifyClaims(ctx, &servicejsonkeys.VerifyClaimsRequest{
-    Usage: servicejsonkeys.KeyUsageAuth,
-    AccessToken: token.GetToken(),
-  })
-
-  // decodedClaims should be the same as claims.
-}
-```
+API reference: [a-novel.github.io/service-json-keys-v2](https://a-novel.github.io/service-json-keys-v2)

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ JSON Keys is a centralized signing-key manager for the A-Novel platform. Service
 
 The service ships two surfaces:
 
-- A **private gRPC API** (signing, key retrieval, status) for authenticated service-to-service traffic. Anything that touches private key material lives here.
+- A **private gRPC API** (signing, key retrieval, status) for internal, private-network service-to-service traffic. Anything that touches private key material lives here. The server itself implements no application-layer authentication; access control is enforced externally — by network policy, ingress, service mesh, or other deployment infrastructure.
 - A **public REST API** (public-key fetch, health) for any client that needs to verify tokens.
 
 State lives in a PostgreSQL database; both surfaces are stateless and can run as multiple replicas behind a load balancer.
@@ -30,7 +30,7 @@ State lives in a PostgreSQL database; both surfaces are stateless and can run as
 
 The minimal local setup is one Postgres image plus one service image. Pin both to the same release tag (current: `v2.2.6`).
 
-The example below runs the gRPC server in **standalone** mode — the simplest path to a working signing API. Set `SERVICE_JSON_KEYS_GRPC_PORT` to whichever port you want to expose.
+The example below runs the gRPC server in **standalone** mode — the simplest path to a working signing API. Set `GRPC_PORT` to whichever port you want to expose.
 
 ```yaml
 services:
@@ -48,7 +48,7 @@ services:
 
   service-json-keys:
     image: ghcr.io/a-novel/service-json-keys/standalone-grpc:v2.2.6
-    ports: ["${SERVICE_JSON_KEYS_GRPC_PORT}:8080"]
+    ports: ["${GRPC_PORT}:8080"]
     depends_on:
       postgres-json-keys: { condition: service_healthy }
     environment:
@@ -101,7 +101,7 @@ services:
 
   service-json-keys:
     image: ghcr.io/a-novel/service-json-keys/grpc:v2.2.6
-    ports: ["${SERVICE_JSON_KEYS_GRPC_PORT}:8080"]
+    ports: ["${GRPC_PORT}:8080"]
     depends_on:
       postgres-json-keys: { condition: service_healthy }
       migrations-json-keys: { condition: service_completed_successfully }
@@ -132,7 +132,7 @@ Configuration is driven by environment variables.
 | `POSTGRES_DSN`   | PostgreSQL connection string.                                                                                                                                                                                       | `standalone-grpc`<br/>`standalone-rest`<br/>`grpc`<br/>`rest`<br/>`migrations` |
 | `APP_MASTER_KEY` | 32-byte hex-encoded master key used to encrypt private keys at rest. **Never rotate** unless you can afford to invalidate every existing private key — see [CONTRIBUTING](./CONTRIBUTING.md#master-key-encryption). | `standalone-grpc`<br/>`standalone-rest`<br/>`grpc`<br/>`rest`                  |
 
-The gRPC surface exposes private-key operations and must run on an isolated, authenticated network.
+The gRPC surface exposes private-key operations and must run on an isolated, access-controlled network. Access control is enforced by deployment infrastructure (network policy, ingress, service mesh) — the server does not authenticate callers itself.
 
 **Optional — REST tuning**
 
@@ -205,7 +205,10 @@ func main() {
 	defer client.Close()
 
 	// Sign claims under the auth usage.
-	payload, _ := grpcf.InterfaceToProtoAny(MyClaims{UserID: "user-1"})
+	payload, err := grpcf.InterfaceToProtoAny(MyClaims{UserID: "user-1"})
+	if err != nil {
+		log.Fatal(err)
+	}
 	res, err := client.ClaimsSign(ctx, &servicejsonkeys.ClaimsSignRequest{
 		Usage:   servicejsonkeys.KeyUsageAuth,
 		Payload: payload,


### PR DESCRIPTION
## Summary

Restructures both docs around three explicit audiences — operators, client integrators, contributors — with one home per fact and an explicit accuracy gate for any claim about the code.

### README

- **New** \"What it does\" section: the first text after the badges is now a short paragraph naming what the service owns (signing keys), who it serves (other A-Novel services), and the surfaces it exposes (private gRPC, public REST). Previously the file jumped straight from badges into compose YAML — readers had to infer the service's role from the env-var table.
- **Single canonical compose block** + deployment-shape table + collapsed \`<details>\` for the production split-image example. Replaces the four serial near-identical compose blocks the previous README shipped. Same coverage, less scrolling, single-place edit when a new variant or tag lands.
- **Configuration as its own subsection**, after the canonical compose example, instead of interleaved with deployment guidance.
- **Tightened Go example**: minimum-viable sign-and-verify walkthrough with real error handling. Also fixes the broken \`NewClient(ctx, addr)\` signature in the previous version (\`NewClient\` takes \`addr, opts...\`).
- **Tightened JS example**: keeps the \`.npmrc\` auth note, install, and one \`jwkList\` call. Defers the full surface to the published API reference and intellisense.

### CONTRIBUTING

- **Removed Prerequisites, Bootstrap, Common Commands**. Per the user direction in this round, these will live in the platform-wide contribution guide the intro already links to. Duplicating them per repo creates a second source of truth that drifts.
- **Removed Go / JS client examples**. They live in the README; contributors are expected to read it first.
- **Corrected \"AES-GCM\" → \"NaCl secretbox (XSalsa20-Poly1305)\"** — the actual algorithm in \`internal/lib/masterKeyCrypt.go\`.
- **Corrected the JWK config schema example** to match \`config.Jwk\` in the source. The previous example used \`algorithm / rotation / expiry\` at the top level; the real schema is \`alg / key.{ttl,rotation,cache} / token.{ttl,issuer,audience,subject,leeway}\`.
- **Replaced the generic Active / Expired / Deleted lifecycle** with the actual main / legacy distinction enforced by the DAO and the \`active_keys\` materialized view.
- **Added a Surfaces table** summarising gRPC vs REST operations and the structural reason signing only reaches the gRPC binary.

### Skill update (separate workspace)

The \`write-project-docs\` skill received a substantial refit in the same direction — added an Editorial Principles section (audience separation, role-first, accuracy gate, canonical-and-variants, reference-don't-enumerate, edit-in-place), restructured the README and CONTRIBUTING template guidance to enforce them, and removed the old Prerequisites/Common-Commands template body that was duplicating org-level setup. Those changes live in the navigator workspace (\`.claude/skills/write-project-docs/SKILL.md\`) and ship in their own PR.

## Test plan

- [x] \`pnpm format\` clean
- [x] \`pnpm lint:stylecheck\` (Prettier) — passes; switched to multi-line top-level \`networks:\` / \`volumes:\` to dodge a Prettier inline-mapping quirk that was producing \`{ api }\` (flow-set, not flow-map) — same surface form as the original repo's other compose blocks.
- [x] All factual claims about the code re-verified against the current SHA: encryption algorithm (NaCl secretbox), config schema (jwks.config.yaml + jwks.config.go), gRPC service names, REST endpoint paths, file references.
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)