### PR TITLE
chore: audit cleanup — disable HMAC, drop orphan proto enum, fix openapi example

### DIFF
--- a/internal/handlers/protogen/jwk.pb.go
+++ b/internal/handlers/protogen/jwk.pb.go
@@ -21,61 +21,6 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
-// A JSON Web Key is always generated for a specific usage. Only a single producer should
-// generate tokens for a given usage; any number of recipients can consume them.
-type JwkUsage int32
-
-const (
-	// JWK_USAGE_UNSPECIFIED is the default value required by proto definition.
-	// It must not be used in an actual request; doing so returns an error.
-	JwkUsage_JWK_USAGE_UNSPECIFIED JwkUsage = 0
-	// JWK_USAGE_AUTH is used to produce access tokens for the authentication service.
-	JwkUsage_JWK_USAGE_AUTH JwkUsage = 1
-	// JWK_USAGE_AUTH_REFRESH is used to produce refresh tokens for the authentication service.
-	JwkUsage_JWK_USAGE_AUTH_REFRESH JwkUsage = 2
-)
-
-// Enum value maps for JwkUsage.
-var (
-	JwkUsage_name = map[int32]string{
-		0: "JWK_USAGE_UNSPECIFIED",
-		1: "JWK_USAGE_AUTH",
-		2: "JWK_USAGE_AUTH_REFRESH",
-	}
-	JwkUsage_value = map[string]int32{
-		"JWK_USAGE_UNSPECIFIED":  0,
-		"JWK_USAGE_AUTH":         1,
-		"JWK_USAGE_AUTH_REFRESH": 2,
-	}
-)
-
-func (x JwkUsage) Enum() *JwkUsage {
-	p := new(JwkUsage)
-	*p = x
-	return p
-}
-
-func (x JwkUsage) String() string {
-	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
-}
-
-func (JwkUsage) Descriptor() protoreflect.EnumDescriptor {
-	return file_jwk_proto_enumTypes[0].Descriptor()
-}
-
-func (JwkUsage) Type() protoreflect.EnumType {
-	return &file_jwk_proto_enumTypes[0]
-}
-
-func (x JwkUsage) Number() protoreflect.EnumNumber {
-	return protoreflect.EnumNumber(x)
-}
-
-// Deprecated: Use JwkUsage.Descriptor instead.
-func (JwkUsage) EnumDescriptor() ([]byte, []int) {
-	return file_jwk_proto_rawDescGZIP(), []int{0}
-}
-
 // Jwk represents a public JSON Web Key. Private key material is never included.
 type Jwk struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
@@ -183,11 +128,7 @@ const file_jwk_proto_rawDesc = "" +
 	"\akey_ops\x18\x03 \x03(\tR\x06keyOps\x12\x10\n" +
 	"\x03alg\x18\x04 \x01(\tR\x03alg\x12\x10\n" +
 	"\x03kid\x18\x05 \x01(\tR\x03kid\x12\x18\n" +
-	"\apayload\x18\x06 \x01(\fR\apayload*U\n" +
-	"\bJwkUsage\x12\x19\n" +
-	"\x15JWK_USAGE_UNSPECIFIED\x10\x00\x12\x12\n" +
-	"\x0eJWK_USAGE_AUTH\x10\x01\x12\x1a\n" +
-	"\x16JWK_USAGE_AUTH_REFRESH\x10\x02BYB\bJwkProtoP\x01ZKgithub.com/a-novel/service-json-keys/v2/internal/handlers/protogen;protogenb\x06proto3"
+	"\apayload\x18\x06 \x01(\fR\apayloadBYB\bJwkProtoP\x01ZKgithub.com/a-novel/service-json-keys/v2/internal/handlers/protogen;protogenb\x06proto3"
 
 var (
 	file_jwk_proto_rawDescOnce sync.Once
@@ -201,11 +142,9 @@ func file_jwk_proto_rawDescGZIP() []byte {
 	return file_jwk_proto_rawDescData
 }
 
-var file_jwk_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
 var file_jwk_proto_msgTypes = make([]protoimpl.MessageInfo, 1)
 var file_jwk_proto_goTypes = []any{
-	(JwkUsage)(0), // 0: JwkUsage
-	(*Jwk)(nil),   // 1: Jwk
+	(*Jwk)(nil), // 0: Jwk
 }
 var file_jwk_proto_depIdxs = []int32{
 	0, // [0:0] is the sub-list for method output_type
@@ -225,14 +164,13 @@ func file_jwk_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_jwk_proto_rawDesc), len(file_jwk_proto_rawDesc)),
-			NumEnums:      1,
+			NumEnums:      0,
 			NumMessages:   1,
 			NumExtensions: 0,
 			NumServices:   0,
 		},
 		GoTypes:           file_jwk_proto_goTypes,
 		DependencyIndexes: file_jwk_proto_depIdxs,
-		EnumInfos:         file_jwk_proto_enumTypes,
 		MessageInfos:      file_jwk_proto_msgTypes,
 	}.Build()
 	File_jwk_proto = out.File

--- a/internal/models/proto/jwk.proto
+++ b/internal/models/proto/jwk.proto
@@ -20,15 +20,3 @@ message Jwk {
   // Algorithm-specific key parameters (e.g., x and crv for EdDSA keys), encoded as JSON bytes.
   bytes payload = 6;
 }
-
-// A JSON Web Key is always generated for a specific usage. Only a single producer should
-// generate tokens for a given usage; any number of recipients can consume them.
-enum JwkUsage {
-  // JWK_USAGE_UNSPECIFIED is the default value required by proto definition.
-  // It must not be used in an actual request; doing so returns an error.
-  JWK_USAGE_UNSPECIFIED = 0;
-  // JWK_USAGE_AUTH is used to produce access tokens for the authentication service.
-  JWK_USAGE_AUTH = 1;
-  // JWK_USAGE_AUTH_REFRESH is used to produce refresh tokens for the authentication service.
-  JWK_USAGE_AUTH_REFRESH = 2;
-}

--- a/internal/services/claims_test.go
+++ b/internal/services/claims_test.go
@@ -61,9 +61,8 @@ func TestClaimsSignAndVerify(t *testing.T) {
 				},
 			}),
 		},
-		HMAC: make(map[string]*jwk.Source[[]byte]),
-		ES:   make(map[string]*jwk.Source[*ecdsa.PrivateKey]),
-		RSA:  make(map[string]*jwk.Source[*rsa.PrivateKey]),
+		ES:  make(map[string]*jwk.Source[*ecdsa.PrivateKey]),
+		RSA: make(map[string]*jwk.Source[*rsa.PrivateKey]),
 	}, testConfig)
 	require.NoError(t, err)
 
@@ -75,9 +74,8 @@ func TestClaimsSignAndVerify(t *testing.T) {
 				},
 			}),
 		},
-		HMAC: make(map[string]*jwk.Source[[]byte]),
-		ES:   make(map[string]*jwk.Source[*ecdsa.PublicKey]),
-		RSA:  make(map[string]*jwk.Source[*rsa.PublicKey]),
+		ES:  make(map[string]*jwk.Source[*ecdsa.PublicKey]),
+		RSA: make(map[string]*jwk.Source[*rsa.PublicKey]),
 	}, testConfig)
 	require.NoError(t, err)
 

--- a/internal/services/jwkGen_test.go
+++ b/internal/services/jwkGen_test.go
@@ -347,9 +347,6 @@ func TestJwkGen(t *testing.T) {
 
 	for _, alg := range []jwa.Alg{
 		jwa.EdDSA,
-		jwa.HS256,
-		jwa.HS384,
-		jwa.HS512,
 		jwa.RS256,
 		jwa.RS384,
 		jwa.RS512,

--- a/internal/services/jwkPresets.go
+++ b/internal/services/jwkPresets.go
@@ -20,23 +20,11 @@ var (
 	// ErrJwkPresetUnknown is returned when a requested algorithm has no corresponding preset entry.
 	ErrJwkPresetUnknown = errors.New("unknown jwk preset")
 	// ErrJwkPresetUnknownAlgorithm is returned when a key configuration references an algorithm
-	// for which no key-source builder is registered.
+	// for which no key-source builder is registered. Only asymmetric algorithms (EdDSA, ECDSA,
+	// RSA, RSA-PSS) are supported — symmetric algorithms like HMAC are deliberately excluded
+	// because their secrets cannot be safely separated into a public-key REST surface.
 	ErrJwkPresetUnknownAlgorithm = errors.New("unknown jwk algorithm")
 )
-
-// JwkPresetsHMAC maps HMAC algorithm identifiers to their JWK generation presets.
-var JwkPresetsHMAC = map[jwa.Alg]jwk.HMACPreset{
-	jwa.HS256: jwk.HS256,
-	jwa.HS384: jwk.HS384,
-	jwa.HS512: jwk.HS512,
-}
-
-// JwsPresetsHMAC maps HMAC algorithm identifiers to their JWS signing/verification presets.
-var JwsPresetsHMAC = map[jwa.Alg]jws.HMACPreset{
-	jwa.HS256: jws.HS256,
-	jwa.HS384: jws.HS384,
-	jwa.HS512: jws.HS512,
-}
 
 // JwkPresetsEcdsa maps ECDSA algorithm identifiers to their JWK generation presets.
 var JwkPresetsEcdsa = map[jwa.Alg]jwk.ECDSAPreset{
@@ -76,17 +64,15 @@ var JwsPresetsRsaPss = map[jwa.Alg]jws.RSAPSSPreset{
 	jwa.PS512: jws.PS512,
 }
 
-// JwkGenAny is the common generator signature. It returns a private key, an optional public key
-// (nil for symmetric algorithms), and the KID strings for each, plus any generation error.
+// JwkGenAny is the common generator signature. It returns the private key, the matching
+// public key, the KID strings for each, plus any generation error. Only asymmetric
+// algorithms are supported, so the public key is always non-nil on success.
 type JwkGenAny func() (any, any, string, string, error)
 
 // JwkGenerators is the registry of key generators keyed by algorithm. JwkGen.Exec uses this
 // to look up the correct generator for a given usage's configured algorithm.
 var JwkGenerators = map[jwa.Alg]JwkGenAny{
 	jwa.EdDSA: JwkGeneratorEd25519,
-	jwa.HS256: JwkGeneratorHs(jwa.HS256),
-	jwa.HS384: JwkGeneratorHs(jwa.HS384),
-	jwa.HS512: JwkGeneratorHs(jwa.HS512),
 	jwa.ES256: JwkGeneratorEs(jwa.ES256),
 	jwa.ES384: JwkGeneratorEs(jwa.ES384),
 	jwa.ES512: JwkGeneratorEs(jwa.ES512),
@@ -106,28 +92,6 @@ func JwkGeneratorEd25519() (any, any, string, string, error) {
 	}
 
 	return priv, pub, priv.KID, pub.KID, nil
-}
-
-// JwkGeneratorHs returns a generator for the given HMAC algorithm.
-// HMAC keys are symmetric, so the returned public key is always nil.
-func JwkGeneratorHs(alg jwa.Alg) func() (any, any, string, string, error) {
-	return func() (any, any, string, string, error) {
-		var (
-			preset jwk.HMACPreset
-			ok     bool
-		)
-
-		if preset, ok = JwkPresetsHMAC[alg]; !ok {
-			return nil, nil, "", "", fmt.Errorf("%w (hmac): %s", ErrJwkPresetUnknown, alg)
-		}
-
-		key, err := jwk.GenerateHMAC(preset)
-		if err != nil {
-			return nil, nil, "", "", err
-		}
-
-		return key, nil, key.KID, "", nil
-	}
 }
 
 // JwkGeneratorEs returns a generator for the given ECDSA algorithm.
@@ -173,10 +137,10 @@ func JwkGeneratorRsa(alg jwa.Alg) func() (any, any, string, string, error) {
 }
 
 // JwkPrivateSources holds typed, cached private-key sources for each supported algorithm family,
-// grouped by usage name, and is used to wire signing plugins for JWT production.
+// grouped by usage name, and is used to wire signing plugins for JWT production. Only asymmetric
+// algorithms are supported; symmetric (HMAC) algorithms are not.
 type JwkPrivateSources struct {
 	EdDSA map[string]*jwk.Source[ed25519.PrivateKey]
-	HMAC  map[string]*jwk.Source[[]byte]
 	ES    map[string]*jwk.Source[*ecdsa.PrivateKey]
 	RSA   map[string]*jwk.Source[*rsa.PrivateKey]
 }
@@ -196,7 +160,6 @@ func NewJwkPrivateSource(
 ) (*JwkPrivateSources, error) {
 	output := &JwkPrivateSources{
 		EdDSA: make(map[string]*jwk.Source[ed25519.PrivateKey]),
-		HMAC:  make(map[string]*jwk.Source[[]byte]),
 		ES:    make(map[string]*jwk.Source[*ecdsa.PrivateKey]),
 		RSA:   make(map[string]*jwk.Source[*rsa.PrivateKey]),
 	}
@@ -214,8 +177,6 @@ func NewJwkPrivateSource(
 		switch keyConfig.Alg {
 		case jwa.EdDSA:
 			output.EdDSA[usage] = jwk.NewED25519PrivateSource(sourceConfig)
-		case jwa.HS256, jwa.HS384, jwa.HS512:
-			output.HMAC[usage] = jwk.NewHMACSource(sourceConfig, JwkPresetsHMAC[keyConfig.Alg])
 		case jwa.ES256, jwa.ES384, jwa.ES512:
 			output.ES[usage] = jwk.NewECDSAPrivateSource(sourceConfig, JwkPresetsEcdsa[keyConfig.Alg])
 		case jwa.RS256, jwa.RS384, jwa.RS512, jwa.PS256, jwa.PS384, jwa.PS512:
@@ -229,10 +190,10 @@ func NewJwkPrivateSource(
 }
 
 // JwkPublicSources holds typed, cached public-key sources for each supported algorithm family,
-// grouped by usage name, and is used to wire verification plugins for JWT consumption.
+// grouped by usage name, and is used to wire verification plugins for JWT consumption. Only
+// asymmetric algorithms are supported; symmetric (HMAC) algorithms are not.
 type JwkPublicSources struct {
 	EdDSA map[string]*jwk.Source[ed25519.PublicKey]
-	HMAC  map[string]*jwk.Source[[]byte]
 	ES    map[string]*jwk.Source[*ecdsa.PublicKey]
 	RSA   map[string]*jwk.Source[*rsa.PublicKey]
 }
@@ -252,7 +213,6 @@ func NewJwkPublicSource(
 ) (*JwkPublicSources, error) {
 	output := &JwkPublicSources{
 		EdDSA: make(map[string]*jwk.Source[ed25519.PublicKey]),
-		HMAC:  make(map[string]*jwk.Source[[]byte]),
 		ES:    make(map[string]*jwk.Source[*ecdsa.PublicKey]),
 		RSA:   make(map[string]*jwk.Source[*rsa.PublicKey]),
 	}
@@ -270,8 +230,6 @@ func NewJwkPublicSource(
 		switch keyConfig.Alg {
 		case jwa.EdDSA:
 			output.EdDSA[usage] = jwk.NewED25519PublicSource(sourceConfig)
-		case jwa.HS256, jwa.HS384, jwa.HS512:
-			output.HMAC[usage] = jwk.NewHMACSource(sourceConfig, JwkPresetsHMAC[keyConfig.Alg])
 		case jwa.ES256, jwa.ES384, jwa.ES512:
 			output.ES[usage] = jwk.NewECDSAPublicSource(sourceConfig, JwkPresetsEcdsa[keyConfig.Alg])
 		case jwa.RS256, jwa.RS384, jwa.RS512, jwa.PS256, jwa.PS384, jwa.PS512:
@@ -299,11 +257,6 @@ func NewJwkProducers(
 	for usage, usageConfig := range sources.EdDSA {
 		signer := jws.NewSourcedED25519Signer(usageConfig)
 		output[usage] = []jwt.ProducerPlugin{signer}
-	}
-
-	for usage, usageConfig := range sources.HMAC {
-		signer := jws.NewSourcedHMACSigner(usageConfig, JwsPresetsHMAC[keys[usage].Alg])
-		output[usage] = append(output[usage], signer)
 	}
 
 	for usage, usageConfig := range sources.ES {
@@ -341,11 +294,6 @@ func NewJwkRecipients(
 	for usage, usageConfig := range sources.EdDSA {
 		recipient := jws.NewSourcedED25519Verifier(usageConfig)
 		output[usage] = []jwt.RecipientPlugin{recipient}
-	}
-
-	for usage, usageConfig := range sources.HMAC {
-		recipient := jws.NewSourcedHMACVerifier(usageConfig, JwsPresetsHMAC[keys[usage].Alg])
-		output[usage] = append(output[usage], recipient)
 	}
 
 	for usage, usageConfig := range sources.ES {

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,4 +1,3 @@
-# Created with https://editor.swagger.io/
 openapi: 3.1.0
 
 servers:
@@ -203,7 +202,7 @@ components:
         - {
             "kty": "OKP",
             "use": "sig",
-            "key_ops": ["sign", "verify"],
+            "key_ops": ["verify"],
             "alg": "EdDSA",
             "kid": "44de7cd7-aff1-e6c4-4204-74e8341d792c",
             "x": "11qYAYKxCrfVS_7TyWQHOg7hcvPapiMlrwIaaPcHURo",


### PR DESCRIPTION
## Summary

Three independent fixes from the closing audit pass over service-json-keys, each its own commit so they can be reviewed (and reverted) independently.

## 1. \`feat(services)!\` — enforce asymmetric algorithms; disable HMAC

The service contract is *\"the producer signs with private key material, recipients verify with public key material\"* — fundamentally an asymmetric model. HMAC fits awkwardly: the secret is the same on both sides, and there is no separable public surface to expose on \`/jwks\`.

Until this commit, the code accepted HMAC anyway. Latent risk path:

1. An operator registers an HMAC usage in \`jwks.config.yaml\`.
2. The DAO row stores the HMAC secret in \`PrivateKey\`, leaves \`PublicKey\` nil (no public counterpart for symmetric keys).
3. The REST and gRPC list/get handlers call \`JwkSearch\` / \`JwkSelect\` with \`Private: false\`. \`JwkExtract\` falls back to the private payload when \`PublicKey == nil\` — leaking the symmetric secret to anyone who can hit \`/jwks\` or \`JwkListService\`.

The README's *\"private key material never leaves the server\"* claim would silently become false. Today the risk is dormant (only EdDSA usages are configured), but the structural footgun shouldn't stay.

This commit removes HMAC at the source. Concrete deletions: \`JwkPresetsHMAC\`, \`JwsPresetsHMAC\`, \`JwkGeneratorHs\`, the \`HS256/384/512\` entries from \`JwkGenerators\`, the \`HMAC\` fields on \`JwkPrivateSources\` / \`JwkPublicSources\`, the HMAC arms in \`NewJwkPrivateSource\` / \`NewJwkPublicSource\` / \`NewJwkProducers\` / \`NewJwkRecipients\`, and the HMAC test cases. Configuring HMAC now fails fast at startup with \`ErrJwkPresetUnknownAlgorithm\`.

\`services\` package coverage went from 78.8% to 81.1% — the removed HMAC paths were largely unreachable from the test suite anyway.

**BREAKING CHANGE**: the \`JwkPrivateSources\` and \`JwkPublicSources\` structs no longer carry an \`HMAC\` field. External callers that build these manually (nearly none — the constructors are the canonical entry point) will fail to compile. Configurations that referenced \`HS256\` / \`HS384\` / \`HS512\` will refuse to come up.

## 2. \`chore(proto)!\` — remove orphan \`JwkUsage\` enum

\`JwkUsage\` (\`JWK_USAGE_UNSPECIFIED\` / \`_AUTH\` / \`_AUTH_REFRESH\`) was defined in \`jwk.proto\` but referenced by zero proto messages, zero Go code, zero tests. The actual usage selectors on \`ClaimsSignRequest\` / \`JwkListRequest\` are plain strings; the exported \`KeyUsageAuth\` / \`KeyUsageAuthRefresh\` string consts in \`pkg/go/claims.go\` carry the contract. Removing the dead enum.

**BREAKING CHANGE**: buf will flag this at the FILE level. No actual consumers exist on the wire, so no clients are affected.

## 3. \`docs(openapi)\` — correct \`key_ops\` example and drop stale editor comment

The Jwk schema example carried \`\"key_ops\": [\"sign\", \"verify\"]\` for what is documented as a *public* JSON Web Key. Public keys returned by the REST endpoints have \`key_ops: [\"verify\"]\` only, per RFC 7517 and per \`kit/jwt/jwk/{ecdsa,rsa}.go\`. The file's other two examples (lines 143 and 162) already showed \`[verify]\`; the schema example was the lone outlier. Also dropped the leading \`# Created with https://editor.swagger.io/\` comment — the file is hand-maintained now.

## Test plan

- [x] \`make format\` clean
- [x] \`make lint-go\` — 0 issues
- [x] \`make test-unit\` — 104 tests pass (down 3 from the HMAC sweep cases that were removed)
- [x] \`pnpm lint:stylecheck\` clean
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)