### PR TITLE
chore(deps): migrate to renamed golib symbols (acronym casing + SetEchoServersContext)

### DIFF
--- a/cmd/grpc/main.go
+++ b/cmd/grpc/main.go
@@ -111,7 +111,7 @@ func main() {
 		),
 	)
 
-	grpcf.SetEchoServers(server, cfg.Grpc.Ping)
+	grpcf.SetEchoServersContext(ctx, server, cfg.Grpc.Ping)
 
 	protogen.RegisterStatusServiceServer(server, handlerStatus)
 	protogen.RegisterClaimsSignServiceServer(server, handlerClaimsSign)

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ tool (
 )
 
 require (
-	github.com/a-novel-kit/golib v0.20.32
+	github.com/a-novel-kit/golib v0.20.33-0.20260515024357-9276b6c23a33
 	github.com/a-novel-kit/jwt v1.1.59
 	github.com/go-chi/chi/v5 v5.2.5
 	github.com/go-chi/cors v1.2.2
@@ -78,7 +78,6 @@ require (
 	github.com/docker/docker-credential-helpers v0.9.6 // indirect
 	github.com/docker/go-connections v0.7.0 // indirect
 	github.com/docker/go-units v0.5.0 // indirect
-	github.com/fatih/color v1.19.0 // indirect
 	github.com/fatih/structs v1.1.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/fsnotify/fsnotify v1.9.0 // indirect
@@ -174,7 +173,7 @@ require (
 	golang.org/x/text v0.37.0 // indirect
 	golang.org/x/time v0.15.0 // indirect
 	golang.org/x/tools v0.44.0 // indirect
-	google.golang.org/api v0.278.0 // indirect
+	google.golang.org/api v0.279.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260427160629-7cedc36a6bc4 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260427160629-7cedc36a6bc4 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ tool (
 )
 
 require (
-	github.com/a-novel-kit/golib v0.20.33-0.20260515024357-9276b6c23a33
+	github.com/a-novel-kit/golib v0.21.0
 	github.com/a-novel-kit/jwt v1.1.59
 	github.com/go-chi/chi/v5 v5.2.5
 	github.com/go-chi/cors v1.2.2

--- a/go.sum
+++ b/go.sum
@@ -61,8 +61,8 @@ github.com/GoogleCloudPlatform/opentelemetry-operations-go/propagator v0.56.0 h1
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/propagator v0.56.0/go.mod h1:sKE2BdlsRRPL7ONGioxJnjUhEA1NbF484vFq8LX6znI=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
-github.com/a-novel-kit/golib v0.20.33-0.20260515024357-9276b6c23a33 h1:yTgp0B27pR6uhj2gPqiH2OHrFS9GQ2DjfYxnVFDog4I=
-github.com/a-novel-kit/golib v0.20.33-0.20260515024357-9276b6c23a33/go.mod h1:kpQ/AzbFg7DrAqFeXObxCI8bCd5O/pG8y4t8tSdO0Yo=
+github.com/a-novel-kit/golib v0.21.0 h1:YeYw75+s7iRYBtV11P9FaaepIevISSwXYf9llzYFV/w=
+github.com/a-novel-kit/golib v0.21.0/go.mod h1:kpQ/AzbFg7DrAqFeXObxCI8bCd5O/pG8y4t8tSdO0Yo=
 github.com/a-novel-kit/jwt v1.1.59 h1:qsaemGgPeISLH49s2PKM2U1zp852Kkr+a0tl9er+ryM=
 github.com/a-novel-kit/jwt v1.1.59/go.mod h1:C8vBO63pmAh1afGl7B+0KExZ1X0d/Dwn/erB8I6Vhw8=
 github.com/antlr4-go/antlr/v4 v4.13.1 h1:SqQKkuVZ+zWkMMNkjy5FZe5mr5WURWnlpmOuzYWrPrQ=

--- a/go.sum
+++ b/go.sum
@@ -61,8 +61,8 @@ github.com/GoogleCloudPlatform/opentelemetry-operations-go/propagator v0.56.0 h1
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/propagator v0.56.0/go.mod h1:sKE2BdlsRRPL7ONGioxJnjUhEA1NbF484vFq8LX6znI=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
-github.com/a-novel-kit/golib v0.20.32 h1:sUY7fXmg+00/I+LbA5oQjU/JiiT1mk3mYy9ToOsXDTM=
-github.com/a-novel-kit/golib v0.20.32/go.mod h1:aOXjKL0tALPv+YwP2GeOL/90IAph2oG2HZQjvgo2sU8=
+github.com/a-novel-kit/golib v0.20.33-0.20260515024357-9276b6c23a33 h1:yTgp0B27pR6uhj2gPqiH2OHrFS9GQ2DjfYxnVFDog4I=
+github.com/a-novel-kit/golib v0.20.33-0.20260515024357-9276b6c23a33/go.mod h1:kpQ/AzbFg7DrAqFeXObxCI8bCd5O/pG8y4t8tSdO0Yo=
 github.com/a-novel-kit/jwt v1.1.59 h1:qsaemGgPeISLH49s2PKM2U1zp852Kkr+a0tl9er+ryM=
 github.com/a-novel-kit/jwt v1.1.59/go.mod h1:C8vBO63pmAh1afGl7B+0KExZ1X0d/Dwn/erB8I6Vhw8=
 github.com/antlr4-go/antlr/v4 v4.13.1 h1:SqQKkuVZ+zWkMMNkjy5FZe5mr5WURWnlpmOuzYWrPrQ=
@@ -129,8 +129,6 @@ github.com/envoyproxy/go-control-plane/envoy v1.37.0 h1:u3riX6BoYRfF4Dr7dwSOroNf
 github.com/envoyproxy/go-control-plane/envoy v1.37.0/go.mod h1:DReE9MMrmecPy+YvQOAOHNYMALuowAnbjjEMkkWOi6A=
 github.com/envoyproxy/protoc-gen-validate v1.3.3 h1:MVQghNeW+LZcmXe7SY1V36Z+WFMDjpqGAGacLe2T0ds=
 github.com/envoyproxy/protoc-gen-validate v1.3.3/go.mod h1:TsndJ/ngyIdQRhMcVVGDDHINPLWB7C82oDArY51KfB0=
-github.com/fatih/color v1.19.0 h1:Zp3PiM21/9Ld6FzSKyL5c/BULoe/ONr9KlbYVOfG8+w=
-github.com/fatih/color v1.19.0/go.mod h1:zNk67I0ZUT1bEGsSGyCZYZNrHuTkJJB+r6Q9VuMi0LE=
 github.com/fatih/structs v1.1.0 h1:Q7juDM0QtcnhCpeyLGQKyg4TOIghuNXrkL32pHAUMxo=
 github.com/fatih/structs v1.1.0/go.mod h1:9NiDSp5zOcgEDl+j00MP/WkGVPOlPRLejGD8Ga6PJ7M=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
@@ -395,8 +393,8 @@ golang.org/x/tools v0.44.0/go.mod h1:KA0AfVErSdxRZIsOVipbv3rQhVXTnlU6UhKxHd1seDI
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gonum.org/v1/gonum v0.17.0 h1:VbpOemQlsSMrYmn7T2OUvQ4dqxQXU+ouZFQsZOx50z4=
 gonum.org/v1/gonum v0.17.0/go.mod h1:El3tOrEuMpv2UdMrbNlKEh9vd86bmQ6vqIcDwxEOc1E=
-google.golang.org/api v0.278.0 h1:W7jiRvRi53VYFfZ/HoZjQBtJk7gOFbHD8ot1RzVZU6E=
-google.golang.org/api v0.278.0/go.mod h1:B9TqLBwJqVjp1mtt7WeoQwWRwvu/400y5lETOql+giQ=
+google.golang.org/api v0.279.0 h1:hsx2M2OaRcaKtVYK6vXEUnQvdjnend7ZYES+lYaot74=
+google.golang.org/api v0.279.0/go.mod h1:B9TqLBwJqVjp1mtt7WeoQwWRwvu/400y5lETOql+giQ=
 google.golang.org/genproto v0.0.0-20260319201613-d00831a3d3e7 h1:XzmzkmB14QhVhgnawEVsOn6OFsnpyxNPRY9QV01dNB0=
 google.golang.org/genproto v0.0.0-20260319201613-d00831a3d3e7/go.mod h1:L43LFes82YgSonw6iTXTxXUX1OlULt4AQtkik4ULL/I=
 google.golang.org/genproto/googleapis/api v0.0.0-20260427160629-7cedc36a6bc4 h1:yOzSCGPx+cp5VO7IxvZ9SBFF7j1tZVcNtlHR2iYKtVo=

--- a/internal/config/app.config.default.go
+++ b/internal/config/app.config.default.go
@@ -21,12 +21,12 @@ const (
 )
 
 // LoggerProdGrpc sends gRPC request logs to Google Cloud Logging.
-var LoggerProdGrpc = loggingpresets.GrpcGcloud{
+var LoggerProdGrpc = loggingpresets.GRPCGcloud{
 	Component: env.GcloudProjectId,
 }
 
 // LoggerDevGrpc prints gRPC request logs to the console in a human-readable format.
-var LoggerDevGrpc = loggingpresets.GrpcLocal{}
+var LoggerDevGrpc = loggingpresets.GRPCLocal{}
 
 // LoggerDev prints HTTP request logs to the console in a human-readable format.
 var LoggerDev = &loggingpresets.LogLocal{
@@ -75,11 +75,11 @@ var AppPresetDefault = App{
 			FlushTimeout: OtelFlushTimeout,
 		}),
 	Logger:     lo.Ternary[logging.Log](env.GcloudProjectId == "", LoggerDev, LoggerProd),
-	GrpcLogger: lo.Ternary[logging.RpcConfig](env.GcloudProjectId == "", &LoggerDevGrpc, &LoggerProdGrpc),
-	RestLogger: lo.Ternary[logging.HttpConfig](
+	GrpcLogger: lo.Ternary[logging.RPCConfig](env.GcloudProjectId == "", &LoggerDevGrpc, &LoggerProdGrpc),
+	RestLogger: lo.Ternary[logging.HTTPConfig](
 		env.GcloudProjectId == "",
-		&loggingpresets.HttpLocal{BaseLogger: LoggerDev},
-		&loggingpresets.HttpGcloud{BaseLogger: LoggerProd},
+		&loggingpresets.HTTPLocal{BaseLogger: LoggerDev},
+		&loggingpresets.HTTPGcloud{BaseLogger: LoggerProd},
 	),
 	Postgres: PostgresPresetDefault,
 }

--- a/internal/config/app.config.go
+++ b/internal/config/app.config.go
@@ -68,9 +68,9 @@ type App struct {
 	// Logger is the base application logger used for general output.
 	Logger logging.Log `json:"logger" yaml:"logger"`
 	// GrpcLogger configures the gRPC request logging middleware.
-	GrpcLogger logging.RpcConfig `json:"grpclogger" yaml:"grpclogger"`
+	GrpcLogger logging.RPCConfig `json:"grpclogger" yaml:"grpclogger"`
 	// RestLogger configures the REST request logging middleware.
-	RestLogger logging.HttpConfig `json:"restLogger" yaml:"restLogger"`
+	RestLogger logging.HTTPConfig `json:"restLogger" yaml:"restLogger"`
 	// Postgres configures the PostgreSQL connection.
 	Postgres postgres.Config `json:"postgres" yaml:"postgres"`
 }

--- a/internal/handlers/grpc.claimsSign.go
+++ b/internal/handlers/grpc.claimsSign.go
@@ -37,7 +37,7 @@ func (handler *GrpcClaimsSign) ClaimsSign(
 	ctx, span := otel.Tracer().Start(ctx, "grpc.ClaimsSign")
 	defer span.End()
 
-	extractedClaims, err := grpcf.ProtoAnyToInterface(request.GetPayload())
+	extractedClaims, err := grpcf.UnmarshalJSONFromAny(request.GetPayload())
 	if err != nil {
 		_ = otel.ReportError(span, err)
 

--- a/internal/handlers/grpc.claimsSign_test.go
+++ b/internal/handlers/grpc.claimsSign_test.go
@@ -43,7 +43,7 @@ func TestGrpcClaimsSign(t *testing.T) {
 			name: "Success",
 
 			request: &protogen.ClaimsSignRequest{
-				Payload: lo.Must(grpcf.InterfaceToProtoAny(map[string]any{"message": "hello world"})),
+				Payload: lo.Must(grpcf.MarshalJSONAsAny(map[string]any{"message": "hello world"})),
 				Usage:   "test-usage",
 			},
 
@@ -61,7 +61,7 @@ func TestGrpcClaimsSign(t *testing.T) {
 			name: "Error/InvalidPayload",
 
 			request: &protogen.ClaimsSignRequest{
-				// Payload not set — grpcf.ProtoAnyToInterface(nil) returns an error.
+				// Payload not set — grpcf.UnmarshalJSONFromAny(nil) returns an error.
 				Usage: "test-usage",
 			},
 
@@ -71,7 +71,7 @@ func TestGrpcClaimsSign(t *testing.T) {
 			name: "Error/BadConfig",
 
 			request: &protogen.ClaimsSignRequest{
-				Payload: lo.Must(grpcf.InterfaceToProtoAny(map[string]any{"message": "hello world"})),
+				Payload: lo.Must(grpcf.MarshalJSONAsAny(map[string]any{"message": "hello world"})),
 				Usage:   "test-usage",
 			},
 
@@ -86,7 +86,7 @@ func TestGrpcClaimsSign(t *testing.T) {
 			name: "Error/Internal",
 
 			request: &protogen.ClaimsSignRequest{
-				Payload: lo.Must(grpcf.InterfaceToProtoAny(map[string]any{"message": "hello world"})),
+				Payload: lo.Must(grpcf.MarshalJSONAsAny(map[string]any{"message": "hello world"})),
 				Usage:   "test-usage",
 			},
 

--- a/pkg/go/claims_test.go
+++ b/pkg/go/claims_test.go
@@ -29,7 +29,7 @@ func TestClaimsVerifier(t *testing.T) {
 		Foo: "bar",
 	}
 
-	cp, err := grpcf.InterfaceToProtoAny(c)
+	cp, err := grpcf.MarshalJSONAsAny(c)
 	require.NoError(t, err)
 
 	signed, err := client.ClaimsSign(t.Context(), &servicejsonkeys.ClaimsSignRequest{


### PR DESCRIPTION
Consumer migrations for three golib changes (golib release: v0.21.0):

| Upstream | What this PR migrates |
|---|---|
| [a-novel-kit/golib#266](https://github.com/a-novel-kit/golib/pull/266) | `logging.HttpConfig`/`RpcConfig` + the four preset structs → `HTTP*`/`RPC*`/`GRPC*` aliases |
| [a-novel-kit/golib#260](https://github.com/a-novel-kit/golib/pull/260) | `grpcf.SetEchoServers` → `grpcf.SetEchoServersContext` |
| [a-novel-kit/golib#265](https://github.com/a-novel-kit/golib/pull/265) | `grpcf.InterfaceToProtoAny` / `ProtoAnyToInterface` → `MarshalJSONAsAny` / `UnmarshalJSONFromAny` (6 call sites; one I missed on the original consumer survey) |

## What changed

- `internal/config/app.config.go`: `RpcConfig`/`HttpConfig` field types.
- `internal/config/app.config.default.go`: `GrpcGcloud`, `GrpcLocal`, `HttpLocal`, `HttpGcloud`, plus the two generic type parameters.
- `cmd/grpc/main.go`: `SetEchoServers(server, …)` → `SetEchoServersContext(ctx, server, …)`. Threads the existing `ctx`; signal-aware ctx wiring is left as a follow-up.
- `internal/handlers/grpc.claimsSign.go` + `internal/handlers/grpc.claimsSign_test.go` + `pkg/go/claims_test.go`: migrate to the renamed grpcf JSON-over-Any helpers (caught by lint-go after re-pin; missed in the original survey).

## Test plan

- [x] `go build ./...` clean
- [ ] CI green