### PR TITLE
test(dao): isolate DAO tests per-database via RunDBTest

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -152,7 +152,3 @@ linters:
           - gocritic
           - err113
           - prealloc
-      - path: dao/(.+)_test.go
-        linters:
-          - paralleltest
-          - tparallel

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ tool (
 )
 
 require (
-	github.com/a-novel-kit/golib v0.21.0
+	github.com/a-novel-kit/golib v0.22.0
 	github.com/a-novel-kit/jwt v1.1.59
 	github.com/go-chi/chi/v5 v5.2.5
 	github.com/go-chi/cors v1.2.2

--- a/go.sum
+++ b/go.sum
@@ -61,8 +61,8 @@ github.com/GoogleCloudPlatform/opentelemetry-operations-go/propagator v0.56.0 h1
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/propagator v0.56.0/go.mod h1:sKE2BdlsRRPL7ONGioxJnjUhEA1NbF484vFq8LX6znI=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
-github.com/a-novel-kit/golib v0.21.0 h1:YeYw75+s7iRYBtV11P9FaaepIevISSwXYf9llzYFV/w=
-github.com/a-novel-kit/golib v0.21.0/go.mod h1:kpQ/AzbFg7DrAqFeXObxCI8bCd5O/pG8y4t8tSdO0Yo=
+github.com/a-novel-kit/golib v0.22.0 h1:vUIC6eal/lzmiyM5Cb4jpc0EhLWyNbhb6CAEgktLrSA=
+github.com/a-novel-kit/golib v0.22.0/go.mod h1:kpQ/AzbFg7DrAqFeXObxCI8bCd5O/pG8y4t8tSdO0Yo=
 github.com/a-novel-kit/jwt v1.1.59 h1:qsaemGgPeISLH49s2PKM2U1zp852Kkr+a0tl9er+ryM=
 github.com/a-novel-kit/jwt v1.1.59/go.mod h1:C8vBO63pmAh1afGl7B+0KExZ1X0d/Dwn/erB8I6Vhw8=
 github.com/antlr4-go/antlr/v4 v4.13.1 h1:SqQKkuVZ+zWkMMNkjy5FZe5mr5WURWnlpmOuzYWrPrQ=

--- a/internal/dao/migrations_test.go
+++ b/internal/dao/migrations_test.go
@@ -1,0 +1,75 @@
+package dao_test
+
+import (
+	"io/fs"
+	"testing"
+	"testing/fstest"
+
+	"github.com/a-novel/service-json-keys/v2/internal/models/migrations"
+)
+
+// cronStubUp creates a no-op `cron` schema so migrations that call
+// cron.schedule / cron.unschedule apply against a database that does not have
+// pg_cron.
+//
+// postgres.RunDBTest gives every test its own freshly created database. pg_cron
+// is inherently single-database (the extension and its `cron` schema live only
+// in the database named by cron.database_name), so a fresh database has no
+// `cron` schema and migration 20250713173700 (`cron.schedule(...)` for the
+// hourly active_keys refresh) would fail with `schema "cron" does not exist`.
+//
+// The scheduled job is irrelevant to tests anyway: it never fires during a test
+// run, and every DAO test that needs a current active_keys materialized view
+// already issues `REFRESH MATERIALIZED VIEW active_keys` itself. So a stub whose
+// schedule/unschedule are no-ops is functionally complete — it only has to let
+// the migration apply.
+const (
+	cronStubUp = `CREATE SCHEMA IF NOT EXISTS cron;
+
+CREATE OR REPLACE FUNCTION cron.schedule(text, text, text)
+RETURNS bigint LANGUAGE sql AS 'SELECT 0::bigint';
+
+CREATE OR REPLACE FUNCTION cron.unschedule(text)
+RETURNS boolean LANGUAGE sql AS 'SELECT true';
+`
+
+	cronStubDown = `DROP SCHEMA IF EXISTS cron CASCADE;
+`
+)
+
+// migrationsWithCronStub returns the embedded migration set with a stub-cron
+// migration prepended. Its 0001-01-01 timestamp sorts (bun orders migrations by
+// the leading numeric version) before every real migration, so the stub `cron`
+// schema exists by the time 20250713173700 runs.
+//
+// It is materialised as an fstest.MapFS rather than an fs.FS overlay so bun's
+// fs.WalkDir-based discovery sees a single, fully-formed directory with no
+// custom fs.FS plumbing.
+func migrationsWithCronStub(t *testing.T) fs.FS {
+	t.Helper()
+
+	merged := fstest.MapFS{}
+
+	err := fs.WalkDir(migrations.Migrations, ".", func(path string, entry fs.DirEntry, err error) error {
+		if err != nil || entry.IsDir() {
+			return err
+		}
+
+		data, err := fs.ReadFile(migrations.Migrations, path)
+		if err != nil {
+			return err
+		}
+
+		merged[path] = &fstest.MapFile{Data: data}
+
+		return nil
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	merged["00010101000000_cron_stub.up.sql"] = &fstest.MapFile{Data: []byte(cronStubUp)}
+	merged["00010101000000_cron_stub.down.sql"] = &fstest.MapFile{Data: []byte(cronStubDown)}
+
+	return merged
+}

--- a/internal/dao/pg.jwkDelete_test.go
+++ b/internal/dao/pg.jwkDelete_test.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/a-novel/service-json-keys/v2/internal/config/configtest"
 	"github.com/a-novel/service-json-keys/v2/internal/dao"
-	"github.com/a-novel/service-json-keys/v2/internal/models/migrations"
 )
 
 func TestPgJwkDelete(t *testing.T) {
@@ -163,10 +162,10 @@ func TestPgJwkDelete(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 
-			postgres.RunIsolatedTransactionalTest(
+			postgres.RunDBTest(
 				t,
 				configtest.PostgresPreset,
-				migrations.Migrations,
+				migrationsWithCronStub(t),
 				func(ctx context.Context, t *testing.T) {
 					t.Helper()
 

--- a/internal/dao/pg.jwkInsert_test.go
+++ b/internal/dao/pg.jwkInsert_test.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/a-novel/service-json-keys/v2/internal/config/configtest"
 	"github.com/a-novel/service-json-keys/v2/internal/dao"
-	"github.com/a-novel/service-json-keys/v2/internal/models/migrations"
 )
 
 func TestPgJwkInsert(t *testing.T) {
@@ -55,10 +54,10 @@ func TestPgJwkInsert(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 
-			postgres.RunIsolatedTransactionalTest(
+			postgres.RunDBTest(
 				t,
 				configtest.PostgresPreset,
-				migrations.Migrations,
+				migrationsWithCronStub(t),
 				func(ctx context.Context, t *testing.T) {
 					t.Helper()
 

--- a/internal/dao/pg.jwkSearch_test.go
+++ b/internal/dao/pg.jwkSearch_test.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/a-novel/service-json-keys/v2/internal/config/configtest"
 	"github.com/a-novel/service-json-keys/v2/internal/dao"
-	"github.com/a-novel/service-json-keys/v2/internal/models/migrations"
 )
 
 func TestPgJwkSearch(t *testing.T) {
@@ -165,10 +164,10 @@ func TestPgJwkSearch(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 
-			postgres.RunIsolatedTransactionalTest(
+			postgres.RunDBTest(
 				t,
 				configtest.PostgresPreset,
-				migrations.Migrations,
+				migrationsWithCronStub(t),
 				func(ctx context.Context, t *testing.T) {
 					t.Helper()
 

--- a/internal/dao/pg.jwkSelect_test.go
+++ b/internal/dao/pg.jwkSelect_test.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/a-novel/service-json-keys/v2/internal/config/configtest"
 	"github.com/a-novel/service-json-keys/v2/internal/dao"
-	"github.com/a-novel/service-json-keys/v2/internal/models/migrations"
 )
 
 func TestPgJwkSelect(t *testing.T) {
@@ -123,10 +122,10 @@ func TestPgJwkSelect(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 
-			postgres.RunIsolatedTransactionalTest(
+			postgres.RunDBTest(
 				t,
 				configtest.PostgresPreset,
-				migrations.Migrations,
+				migrationsWithCronStub(t),
 				func(ctx context.Context, t *testing.T) {
 					t.Helper()
 


### PR DESCRIPTION
## Summary

- Switches the DAO suite from `postgres.RunIsolatedTransactionalTest` (fresh throwaway schema + **full re-migration per test**) to `postgres.RunDBTest` (migrate a template **once**, clone it per test) — the same isolation model as service-authentication / service-template, and meaningfully faster.
- `t.Parallel()` was already present; drops the now-unneeded `dao/(.+)_test.go` `paralleltest`/`tparallel` golangci exclusion so it stays lint-enforced.
- Bumps golib `v0.21.0` → `v0.22.0` (released; json-keys master already migrated to the renamed golib symbols in #608).

## The pg_cron wrinkle (and why this is still clean)

`RunDBTest` creates a brand-new database per test. pg_cron is inherently single-database (its `cron` schema lives only in `cron.database_name`), so a fresh database has no `cron` schema and migration `20250713173700` (`cron.schedule(...)` for the hourly `active_keys` refresh) would fail with `schema "cron" does not exist`.

Resolved with a **test-only stub**: `migrationsWithCronStub` (in `internal/dao/migrations_test.go`) prepends a `0001-01-01`-timestamped migration that creates a no-op `cron` schema, so it applies before `20250713173700`. This is functionally complete because the scheduled job never fires during a test run anyway, and every DAO test that needs a current `active_keys` matview already issues `REFRESH MATERIALIZED VIEW active_keys` itself.

**No production migration, Docker image, or golib change** — the stub lives entirely in DAO test code; production/integration/dev paths and `RunIsolatedTransactionalTest` elsewhere are untouched.

## Layers changed

- **DAO (tests only)**: 4 `*_test.go` switched to `RunDBTest`; new `migrations_test.go` test helper. No production code changed.
- **Config**: `.golangci.yaml` — dropped the `dao/*_test.go` parallel-linter exclusion.
- **deps**: golib → v0.22.0.

## Validation

Full `internal/dao` suite against the test Postgres: **green in ~4.3s**, all sub-tests `t.Parallel()`. `golangci-lint ./internal/dao/...` clean.

## Breaking changes

None.

## Test plan

- [x] `internal/dao` suite green under full parallelism (local, real Postgres)
- [x] `golangci-lint ./internal/dao/...` clean
- [x] `go build ./...` clean (golib v0.22.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)