### PR TITLE
fix(scripts): bump versions with pnpm -r in publish.sh

### DIFF
--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -10,7 +10,14 @@ if [ $# -ne 1 ]; then
     exit 1
 fi
 
-pnpm version "$1" --workspaces --workspaces-update=false --no-git-tag-version
+# npm (not pnpm) owns the version bump: --workspaces / --workspaces-update are
+# npm flags. Older pnpm proxied `pnpm version` to npm so they were accepted;
+# pnpm >=11 parses `version` itself and rejects them ("Unknown options:
+# 'workspaces', 'workspaces-update'"). The root package.json declares an npm
+# `workspaces` array (incl. "."), so `npm version --workspaces` bumps the root
+# and every member; --workspaces-update=false keeps interdependency ranges and
+# --no-git-tag-version leaves the commit/tag to this script.
+npm version "$1" --workspaces --workspaces-update=false --no-git-tag-version
 pnpm prepublish:doc
 
 VERSION="$(node -p "require('./package.json').version")"

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -10,14 +10,14 @@ if [ $# -ne 1 ]; then
     exit 1
 fi
 
-# npm (not pnpm) owns the version bump: --workspaces / --workspaces-update are
-# npm flags. Older pnpm proxied `pnpm version` to npm so they were accepted;
-# pnpm >=11 parses `version` itself and rejects them ("Unknown options:
-# 'workspaces', 'workspaces-update'"). The root package.json declares an npm
-# `workspaces` array (incl. "."), so `npm version --workspaces` bumps the root
-# and every member; --workspaces-update=false keeps interdependency ranges and
-# --no-git-tag-version leaves the commit/tag to this script.
-npm version "$1" --workspaces --workspaces-update=false --no-git-tag-version
+# Bump the root project and every workspace member. --workspaces /
+# --workspaces-update are npm flags; pnpm <11 silently proxied `pnpm version`
+# to npm so they worked, but pnpm >=11 has a native `version` command that
+# rejects them ("Unknown options: 'workspaces', 'workspaces-update'"). The
+# pnpm-native equivalent is --recursive, which versions the workspace root and
+# every member in one pass; pnpm always skips the git commit/tag in recursive
+# mode, so this script still owns the commit/tag/push below.
+pnpm version "$1" --recursive
 pnpm prepublish:doc
 
 VERSION="$(node -p "require('./package.json').version")"


### PR DESCRIPTION
## Summary

`pnpm publish:patch` (→ `scripts/publish.sh patch`) fails at the version bump:

```
$ bash scripts/publish.sh patch
[ERROR] Unknown options: 'workspaces', 'workspaces-update'
```

`--workspaces` / `--workspaces-update` are **npm** flags. pnpm <11 proxied `pnpm version` to `npm version`, so they were accepted (2.3.0 and earlier shipped fine). **pnpm 11** (recent Renovate bump) ships a *native* `version` command with its own flag set and rejects the npm-only options.

## Fix (pnpm-native, no npm fallback)

`pnpm version "$1" --workspaces --workspaces-update=false --no-git-tag-version` → **`pnpm version "$1" --recursive`**.

`--recursive` is pnpm's workspace equivalent of npm's `--workspaces`: it versions the workspace **root project and every member** in one pass. pnpm **always skips the git commit/tag in recursive mode**, so `--no-git-tag-version` is implied and the script keeps owning the commit/tag/push. `--workspaces-update=false` has no analogue and needs none here — there are no cross-member `workspace:` dependency ranges to rewrite.

(The first commit on this branch used `npm version` as a literal-equivalent workaround; the second replaces it with the pnpm-native form so the toolchain stays pnpm-only.)

## What changed in pnpm 11

`pnpm version` is no longer a passthrough to `npm version` — it is a first-class command (`--recursive`, `--filter`, `--no-git-tag-version`, `--no-git-checks`, `--message`, `--preid`, `--tag-version-prefix`, …) and does not understand npm's `--workspaces`/`--workspaces-update`. Note a gotcha: a bare interactive `pnpm version …` may still fall through to npm (you'll see `npm warn Unknown cli config`); only the in-`pnpm run` path (i.e. `pnpm publish:*`) uses the native command, which is why the failure only reproduces through `pnpm publish:patch`.

## Validation

Reproduced the failure via the real `pnpm publish:patch`, then verified the fix end-to-end with the same entrypoint (git commit/tag/push stubbed so nothing was actually released):

- before: `[ERROR] Unknown options: 'workspaces', 'workspaces-update'` → exit 1
- after: `service-json-keys-project` (root) + `@a-novel/service-json-keys-rest` + `service-json-keys-rest-test-project` all `2.3.0 → 2.3.1` consistently; `prepublish:doc` applied (README image tags + `openapi.yaml`); no npm proxy; no git side effects from the bump. `bash -n` clean.

## Layers changed

- **scripts**: `scripts/publish.sh` — version bump now via `pnpm version --recursive`.

## Breaking changes

None — restores pre-pnpm-11 behaviour, pnpm-natively.

## Test plan

- [x] Reproduced original failure via `pnpm publish:patch`
- [x] Post-fix `pnpm publish:patch` runs through bump + prepublish:doc + (stubbed) commit/tag/push
- [x] `bash -n scripts/publish.sh` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)