### PR TITLE
feat(builds): profile app services for local run

### DIFF
--- a/builds/podman-compose.yaml
+++ b/builds/podman-compose.yaml
@@ -16,7 +16,13 @@ services:
     volumes:
       - json-keys-postgres-data:/var/lib/postgresql/
 
+  # Profiled so a plain `podman compose up` does NOT start it: when the CLI
+  # runs this entrypoint locally (go run) it only needs the deps (postgres);
+  # a containerised copy on the same host ${GRPC_PORT} would collide
+  # ("bind: address already in use"). `--profile grpc` opts into the
+  # dockerised copy instead (per-repo dockerised run mode).
   service-json-keys-grpc:
+    profiles: ["grpc"]
     build:
       context: ..
       dockerfile: ./builds/standalone.grpc.Dockerfile
@@ -31,7 +37,11 @@ services:
     networks:
       - api
 
+  # Same rationale as grpc above: profiled out of the default `up` so the
+  # locally-run REST entrypoint owns ${REST_PORT}. `--profile rest` opts
+  # into the dockerised copy.
   service-json-keys-rest:
+    profiles: ["rest"]
     build:
       context: ..
       dockerfile: ./builds/standalone.rest.Dockerfile

--- a/scripts/setup-env.sh
+++ b/scripts/setup-env.sh
@@ -3,34 +3,5 @@
 # assign-if-unset pattern (${VAR:=default}), so pre-exported values are preserved and only
 # missing ones are filled in. Source this file before running any local service or test command.
 
-# ---- Ports ----
-# Ports are allocated randomly via get-port-please to avoid conflicts when multiple instances
-# run concurrently. Override by exporting a value before sourcing.
-
-REST_PORT="${REST_PORT:="$(node -e 'console.log(await (await import("get-port-please")).getRandomPort())')"}"
-export REST_PORT
-printf "Exposing REST on port %s\n" "${REST_PORT}"
-GRPC_PORT="${GRPC_PORT:="$(node -e 'console.log(await (await import("get-port-please")).getRandomPort())')"}"
-export GRPC_PORT
-printf "Exposing gRPC on port %s\n" "${GRPC_PORT}"
-POSTGRES_PORT="${POSTGRES_PORT:="$(node -e 'console.log(await (await import("get-port-please")).getRandomPort())')"}"
-export POSTGRES_PORT
-
-# ---- Credentials ----
-
 # Dummy master key for local use only — never use this value in production or any shared environment.
 export APP_MASTER_KEY="${APP_MASTER_KEY:="fec0681a2f57242211c559ca347721766f8a3acd8ed2e63b36b3768051c702ca"}"
-
-# ---- Service URLs ----
-
-export GRPC_URL="${GRPC_URL:="localhost:${GRPC_PORT}"}"
-export REST_URL="${REST_URL:="http://localhost:${REST_PORT}"}"
-
-# ---- Database (Postgres) ----
-
-export POSTGRES_USER="${POSTGRES_USER:="postgres"}"
-export POSTGRES_PASSWORD="${POSTGRES_PASSWORD:="postgres"}"
-export POSTGRES_DB="${POSTGRES_DB:="json-keys"}"
-export POSTGRES_HOST="${POSTGRES_HOST:="localhost"}"
-# Full DSN assembled from the individual fields above; override directly to use a non-standard connection string.
-export POSTGRES_DSN="${POSTGRES_DSN:="postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}?sslmode=disable"}"


### PR DESCRIPTION
## Summary

- Profile-guard the containerised app services (`service-json-keys-grpc`, `service-json-keys-rest`) so a plain `podman compose up` starts only the profile-less `postgres-json-keys` dependency. Fixes `bind: address already in use` when `a-novel run` brings the env up for deps and runs the entrypoint locally on the same host port.
- `--profile grpc` / `--profile rest` opt into a dockerised copy.
- Trim `scripts/setup-env.sh` to service constants only: the CLI now owns port/URL/DSN allocation; the script keeps just the local-only `APP_MASTER_KEY`.

## Layers changed

- **builds**: `profiles:` on the two app services in `podman-compose.yaml`.
- **scripts**: `setup-env.sh` reduced to `APP_MASTER_KEY`.

## Breaking changes

None for production. Local: a bare `podman compose ... up` now starts only postgres; pass `--profile grpc`/`--profile rest` for the containers. `setup-env.sh` no longer exports ports/URLs/DSN — the a-novel CLI provides them.

## Test plan

- [x] `podman compose -f builds/podman-compose.yaml config --services` → postgres only; profile flags add the right service.
- [ ] `a-novel run` → select `rest` → no bind clash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
