### PR TITLE
docs(readme): drop the codecov graph token from badge URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@
 
 ![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/a-novel/service-json-keys/main.yaml)
 [![Go Report Card](https://goreportcard.com/badge/github.com/a-novel/service-json-keys)](https://goreportcard.com/report/github.com/a-novel/service-json-keys)
-[![codecov](https://codecov.io/gh/a-novel/service-json-keys/graph/badge.svg?token=almKepuGQE)](https://codecov.io/gh/a-novel/service-json-keys)
+[![codecov](https://codecov.io/gh/a-novel/service-json-keys/graph/badge.svg)](https://codecov.io/gh/a-novel/service-json-keys)
 
-![Coverage graph](https://codecov.io/gh/a-novel/service-json-keys/graphs/sunburst.svg?token=almKepuGQE)
+![Coverage graph](https://codecov.io/gh/a-novel/service-json-keys/graphs/sunburst.svg)
 
 ## What it does
 


### PR DESCRIPTION
Public-repo Codecov badges render without a token, so the graph token in the badge + sunburst URLs is unnecessary. Stripping it for cleaner, tokenless badges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)