### PR TITLE
chore(deps): drop unused js-yaml devDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
     "eslint-plugin-svelte": "^3.19.0",
     "globals": "^17.0.0",
     "jiti": "^2.6.1",
-    "js-yaml": "^4.1.1",
     "jsdom": "^29.0.0",
     "prettier": "^3.6.2",
     "prettier-plugin-packagejson": "^3.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -83,9 +83,6 @@ importers:
       jiti:
         specifier: ^2.6.1
         version: 2.7.0
-      js-yaml:
-        specifier: ^4.1.1
-        version: 4.2.0
       jsdom:
         specifier: ^29.0.0
         version: 29.1.1(@noble/hashes@1.8.0)
@@ -1629,10 +1626,6 @@ packages:
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
-
-  js-yaml@4.2.0:
-    resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
-    hasBin: true
 
   jsdom@28.1.0:
     resolution: {integrity: sha512-0+MoQNYyr2rBHqO1xilltfDjV9G7ymYGlAUazgcDLQaUf8JDHbuGwsxN6U9qWaElZ4w1B2r7yEGIL3GdeW3Rug==}
@@ -3802,10 +3795,6 @@ snapshots:
   js-tokens@10.0.0: {}
 
   js-tokens@4.0.0: {}
-
-  js-yaml@4.2.0:
-    dependencies:
-      argparse: 2.0.1
 
   jsdom@28.1.0(@noble/hashes@1.8.0):
     dependencies:


### PR DESCRIPTION
## What

Removes the `js-yaml` `devDependency`. It is declared but **never imported** in any source file or script, and nothing depends on it transitively (zero consumers in `pnpm-lock.yaml`).

## Why

Renovate opened #725 to bump `js-yaml` `4 → 5` (a large breaking rewrite). Rather than carry — let alone major-bump — an unused dependency, the cleanup is to drop it. This supersedes #725, which will be closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)