### PR TITLE
ci: lane-suffix test job + drop the build-job- infix

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -53,7 +53,7 @@ jobs:
           app_id: ${{ vars.DEPENDENCY_BOT_ID }}
           lint_action: "lint:ci"
 
-  test:
+  test-go:
     needs: [lint-go, build-database]
     runs-on: ubuntu-latest
     permissions:
@@ -250,8 +250,8 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           run_args: -e POSTGRES_DSN="${POSTGRES_DSN}"
 
-  build-job-rotate-keys:
-    needs: [test, build-database]
+  build-rotate-keys:
+    needs: [test-go, build-database]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -288,7 +288,7 @@ jobs:
           run_args: -e POSTGRES_DSN="${POSTGRES_DSN}" -e APP_MASTER_KEY="${APP_MASTER_KEY}"
 
   build-grpc:
-    needs: [test, build-database]
+    needs: [test-go, build-database]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -325,7 +325,7 @@ jobs:
           run_args: -e POSTGRES_DSN="${POSTGRES_DSN}" -e APP_MASTER_KEY="${APP_MASTER_KEY}"
 
   build-standalone-grpc:
-    needs: [test, build-database]
+    needs: [test-go, build-database]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -365,7 +365,7 @@ jobs:
           run_args: -e POSTGRES_DSN="${POSTGRES_DSN}" -e APP_MASTER_KEY="${APP_MASTER_KEY}"
 
   build-rest:
-    needs: [test, build-database]
+    needs: [test-go, build-database]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -402,7 +402,7 @@ jobs:
           run_args: -e POSTGRES_DSN="${POSTGRES_DSN}" -e APP_MASTER_KEY="${APP_MASTER_KEY}"
 
   build-standalone-rest:
-    needs: [test, build-database]
+    needs: [test-go, build-database]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -458,7 +458,7 @@ jobs:
   report-grc:
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/master' && success()
-    needs: [test, test-pkg]
+    needs: [test-go, test-pkg]
     permissions:
       contents: read
     steps:
@@ -467,7 +467,7 @@ jobs:
 
   report-codecov:
     runs-on: ubuntu-latest
-    needs: [test, test-pkg, test-pkg-js]
+    needs: [test-go, test-pkg, test-pkg-js]
     permissions:
       contents: read
     steps:


### PR DESCRIPTION
Renames the CI jobs to match the master ruleset `repo update` reconciled: `test` → `test-go`, and `build-job-rotate-keys` → `build-rotate-keys` (consistent with the other `build-*` targets). `test-pkg` / `test-pkg-js` are unchanged. Refs a-novel-kit/.github#40

🤖 Generated with [Claude Code](https://claude.com/claude-code)