### PR TITLE
feat(ci): dispatched release on workflows v1.3.0

### DIFF
--- a/.github/workflows/auto-assign-author.yaml
+++ b/.github/workflows/auto-assign-author.yaml
@@ -9,7 +9,6 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    if: ${{ github.event.pull_request.user.login != vars.DEPENDENCY_BOT_LOGIN }}
     steps:
       - uses: a-novel-kit/workflows/generic-actions/assign-bot@v1.3.0
         with:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -50,7 +50,7 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           app_private_key: ${{ secrets.DEPENDENCY_BOT_PRIVATE_KEY }}
-          app_id: ${{ vars.DEPENDENCY_BOT_ID }}
+          client_id: ${{ vars.DEPENDENCY_BOT_CLIENT_ID }}
           lint_action: "lint:ci"
 
   test-go:
@@ -183,7 +183,7 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           app_private_key: ${{ secrets.DEPENDENCY_BOT_PRIVATE_KEY }}
-          app_id: ${{ vars.DEPENDENCY_BOT_ID }}
+          client_id: ${{ vars.DEPENDENCY_BOT_CLIENT_ID }}
           coverage_artifact: jscover
           test_action: "test:ci"
 
@@ -452,7 +452,7 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           app_private_key: ${{ secrets.DEPENDENCY_BOT_PRIVATE_KEY }}
-          app_id: ${{ vars.DEPENDENCY_BOT_ID }}
+          client_id: ${{ vars.DEPENDENCY_BOT_CLIENT_ID }}
           build_action: "build:rest"
 
   report-grc:

--- a/.github/workflows/node-audit.yaml
+++ b/.github/workflows/node-audit.yaml
@@ -15,4 +15,4 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           app_private_key: ${{ secrets.PUBLISH_BOT_PRIVATE_KEY }}
-          app_id: ${{ vars.PUBLISH_BOT_ID }}
+          client_id: ${{ vars.PUBLISH_BOT_CLIENT_ID }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,21 +1,63 @@
 name: release
 
+# Releases are cut from the GitHub UI (Actions ▸ release ▸ pick a type ▸ Run),
+# not from a tag push. workflow_call exposes the same inputs so an agent can
+# drive an identical release later. The protected `release` environment is the
+# "who can publish" gate (configure its required reviewers).
+#
+# The build jobs run on the default branch (the dispatch ref), not a tag, so
+# each tags its image from the explicit release version (build-actions `version:`
+# input) and pulls the database service image at the new tag; build-js publishes
+# from the release tag (ref) so the package carries the bumped version.
 on:
-  push:
-    tags:
-      - "**"
+  workflow_dispatch:
+    inputs:
+      release_type:
+        description: Version bump to cut
+        required: true
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+      dry_run:
+        description: Bump & report only — no commit, tag, push, or release
+        required: false
+        type: boolean
+        default: false
+  workflow_call:
+    inputs:
+      release_type:
+        required: true
+        type: string
+      dry_run:
+        required: false
+        type: boolean
+        default: false
+
+run-name: "🚀 release ${{ inputs.release_type }}${{ inputs.dry_run && ' (dry-run)' || '' }}"
 
 jobs:
   release:
     runs-on: ubuntu-latest
+    environment: release
     permissions:
       contents: write
+    outputs:
+      version: ${{ steps.core.outputs.version }}
+      tag: ${{ steps.core.outputs.tag }}
     steps:
-      - uses: a-novel-kit/workflows/publish-actions/auto-release@v1.3.0
+      - id: core
+        uses: a-novel-kit/workflows/publish-actions/release-core@v1.3.0
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          release_type: ${{ inputs.release_type }}
+          dry_run: ${{ inputs.dry_run }}
+          client_id: ${{ vars.AGENT_BOT_CLIENT_ID }}
+          app_private_key: ${{ secrets.AGENT_BOT_PRIVATE_KEY }}
 
   build-database:
+    needs: [release]
+    if: ${{ !inputs.dry_run }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -33,6 +75,7 @@ jobs:
         with:
           file: builds/database.Dockerfile
           image_name: ${{ github.repository }}/database
+          version: ${{ needs.release.outputs.version }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           run_args: >-
             -e POSTGRES_PASSWORD="${POSTGRES_PASSWORD}" 
@@ -43,7 +86,8 @@ jobs:
 
   build-migrations:
     runs-on: ubuntu-latest
-    needs: [build-database]
+    needs: [release, build-database]
+    if: ${{ !inputs.dry_run }}
     permissions:
       contents: read
       packages: write
@@ -51,7 +95,7 @@ jobs:
       id-token: write
     services:
       postgres-json-keys:
-        image: ghcr.io/a-novel/service-json-keys/database:${{ github.ref_name }}
+        image: ghcr.io/a-novel/service-json-keys/database:${{ needs.release.outputs.tag }}
         ports:
           - "5432:5432"
         env:
@@ -72,12 +116,14 @@ jobs:
         with:
           file: builds/migrations.Dockerfile
           image_name: ${{ github.repository }}/jobs/migrations
+          version: ${{ needs.release.outputs.version }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           run_args: -e POSTGRES_DSN="${POSTGRES_DSN}"
 
   build-job-rotate-keys:
     runs-on: ubuntu-latest
-    needs: [build-database]
+    needs: [release, build-database]
+    if: ${{ !inputs.dry_run }}
     permissions:
       contents: read
       packages: write
@@ -85,7 +131,7 @@ jobs:
       id-token: write
     services:
       postgres-json-keys:
-        image: ghcr.io/a-novel/service-json-keys/database:${{ github.ref_name }}
+        image: ghcr.io/a-novel/service-json-keys/database:${{ needs.release.outputs.tag }}
         ports:
           - "5432:5432"
         env:
@@ -109,11 +155,13 @@ jobs:
         with:
           file: builds/rotate-keys.Dockerfile
           image_name: ${{ github.repository }}/jobs/rotatekeys
+          version: ${{ needs.release.outputs.version }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           run_args: -e POSTGRES_DSN="${POSTGRES_DSN}" -e APP_MASTER_KEY="${APP_MASTER_KEY}"
 
   build-grpc:
-    needs: [build-database]
+    needs: [release, build-database]
+    if: ${{ !inputs.dry_run }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -122,7 +170,7 @@ jobs:
       id-token: write
     services:
       postgres-json-keys:
-        image: ghcr.io/a-novel/service-json-keys/database:${{ github.ref_name }}
+        image: ghcr.io/a-novel/service-json-keys/database:${{ needs.release.outputs.tag }}
         ports:
           - "5432:5432"
         env:
@@ -146,11 +194,13 @@ jobs:
         with:
           file: builds/grpc.Dockerfile
           image_name: ${{ github.repository }}/grpc
+          version: ${{ needs.release.outputs.version }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           run_args: -e POSTGRES_DSN="${POSTGRES_DSN}" -e APP_MASTER_KEY="${APP_MASTER_KEY}"
 
   build-standalone-grpc:
-    needs: [build-database]
+    needs: [release, build-database]
+    if: ${{ !inputs.dry_run }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -159,7 +209,7 @@ jobs:
       id-token: write
     services:
       postgres-json-keys:
-        image: ghcr.io/a-novel/service-json-keys/database:${{ github.ref_name }}
+        image: ghcr.io/a-novel/service-json-keys/database:${{ needs.release.outputs.tag }}
         ports:
           - "5432:5432"
         env:
@@ -183,11 +233,13 @@ jobs:
         with:
           file: builds/standalone.grpc.Dockerfile
           image_name: ${{ github.repository }}/standalone-grpc
+          version: ${{ needs.release.outputs.version }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           run_args: -e POSTGRES_DSN="${POSTGRES_DSN}" -e APP_MASTER_KEY="${APP_MASTER_KEY}"
 
   build-rest:
-    needs: [build-database]
+    needs: [release, build-database]
+    if: ${{ !inputs.dry_run }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -196,7 +248,7 @@ jobs:
       id-token: write
     services:
       postgres-json-keys:
-        image: ghcr.io/a-novel/service-json-keys/database:${{ github.ref_name }}
+        image: ghcr.io/a-novel/service-json-keys/database:${{ needs.release.outputs.tag }}
         ports:
           - "5432:5432"
         env:
@@ -220,11 +272,13 @@ jobs:
         with:
           file: builds/rest.Dockerfile
           image_name: ${{ github.repository }}/rest
+          version: ${{ needs.release.outputs.version }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           run_args: -e POSTGRES_DSN="${POSTGRES_DSN}" -e APP_MASTER_KEY="${APP_MASTER_KEY}"
 
   build-standalone-rest:
-    needs: [build-database]
+    needs: [release, build-database]
+    if: ${{ !inputs.dry_run }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -233,7 +287,7 @@ jobs:
       id-token: write
     services:
       postgres-json-keys:
-        image: ghcr.io/a-novel/service-json-keys/database:${{ github.ref_name }}
+        image: ghcr.io/a-novel/service-json-keys/database:${{ needs.release.outputs.tag }}
         ports:
           - "5432:5432"
         env:
@@ -257,12 +311,15 @@ jobs:
         with:
           file: builds/standalone.rest.Dockerfile
           image_name: ${{ github.repository }}/standalone-rest
+          version: ${{ needs.release.outputs.version }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           run_args: -e POSTGRES_DSN="${POSTGRES_DSN}" -e APP_MASTER_KEY="${APP_MASTER_KEY}"
 
+  # Publish the JS client from the bumped tag (ref) so it carries the new
+  # version rather than the pre-bump default branch.
   build-js:
-    needs:
-      - release
+    needs: [release]
+    if: ${{ !inputs.dry_run }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -272,4 +329,28 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           app_private_key: ${{ secrets.PUBLISH_BOT_PRIVATE_KEY }}
-          app_id: ${{ vars.PUBLISH_BOT_ID }}
+          client_id: ${{ vars.PUBLISH_BOT_CLIENT_ID }}
+          ref: ${{ needs.release.outputs.tag }}
+
+  # Everything shipped — clear this repo's awaiting-release board items.
+  archive:
+    needs:
+      - release
+      - build-database
+      - build-migrations
+      - build-job-rotate-keys
+      - build-grpc
+      - build-standalone-grpc
+      - build-rest
+      - build-standalone-rest
+      - build-js
+    if: ${{ !inputs.dry_run }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: a-novel-kit/workflows/generic-actions/archive-board-items@v1.3.0
+        with:
+          client_id: ${{ vars.AGENT_BOT_CLIENT_ID }}
+          app_private_key: ${{ secrets.AGENT_BOT_PRIVATE_KEY }}
+          project_id: ${{ github.repository_owner == 'a-novel' && 'PVT_kwDOB9MxdM4BMh8r' || 'PVT_kwDOCy-nAM4BbtKH' }}

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -33,4 +33,4 @@ jobs:
             ]
           github_token: ${{ secrets.GITHUB_TOKEN }}
           app_private_key: ${{ secrets.DEPENDENCY_BOT_PRIVATE_KEY }}
-          app_id: ${{ vars.DEPENDENCY_BOT_ID }}
+          client_id: ${{ vars.DEPENDENCY_BOT_CLIENT_ID }}


### PR DESCRIPTION
## Summary

Migrate the release workflow off the legacy tag-push `auto-release` flow to the new UI/agent-**dispatched** flow on `a-novel-kit/workflows` **v1.3.0**.

- `on:` is now `workflow_dispatch` (inputs `release_type` choice patch/minor/major + `dry_run` boolean) **and** `workflow_call` (same inputs), with a `run-name` reflecting the type and dry-run state.
- `release` job runs in the protected `release` environment and uses `publish-actions/release-core@v1.3.0` to bump/tag/push, exposing `version` and `tag` outputs.
- Every `build-*` job now `needs: [release]`, is gated on `!inputs.dry_run`, tags its image from the release version (`build-actions` `version:`), and pulls the database service image at `needs.release.outputs.tag`.
- `build-js` publishes from the release tag (`ref`) with the PUBLISH bot `client_id`.
- New `archive` job clears the org board's awaiting-release items once everything ships.
- CI cleanup: `app_id` → `client_id` across all workflows, and dropped the `auto-assign-author` dependency-bot guard so it runs for bot PRs.

## Test plan

- [ ] Dispatch a patch release (Actions ▸ release ▸ patch ▸ Run) and confirm release-core bumps/tags, the docker/job images publish at the new version, the database service pulls at the new tag, build-js publishes the bumped package, and the archive job clears the board.

Part of a-novel-kit/.github#36.

🤖 Generated with [Claude Code](https://claude.com/claude-code)