### PR TITLE
ci: serialize Pages deployments in publish-docs

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -481,6 +481,11 @@ jobs:
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/master' && success()
     needs: [build-js]
+    # GitHub Pages allows a single deployment in flight per site; without this
+    # group, concurrent master runs fail with "in progress deployment" errors.
+    concurrency:
+      group: github-pages
+      cancel-in-progress: false
     permissions:
       contents: read
       pages: write


### PR DESCRIPTION
## Summary

- GitHub Pages allows a single deployment in flight per site, so bursts of pushes to master (e.g. repocfg sync commits landing seconds apart) made `publish-docs` fail with `400: in progress deployment` errors — see service-json-keys runs 28595378401/28601487112 for the failure pattern.
- Adds a job-level `github-pages` concurrency group to `publish-docs` so concurrent deploys queue instead of racing; `cancel-in-progress: false` lets an active deploy finish, matching the official Pages starter workflow.

## Breaking changes

None.

## Test plan

- [x] `prettier --check .github/workflows/main.yaml` passes (pinned 3.9.3)
- [ ] CI green