### PR TITLE
docs: refocus comments on rationale and correct stale doc claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,13 +32,13 @@ The service runs as published OCI images plus a PostgreSQL database. Both server
 
 > **OpenTofu modules are the planned canonical deployment path.** Until they land, deploy the images with any container orchestrator — the composition below is the reference for which images to run, how they wire together, and the environment they expect.
 
-| Image                               | Role                                                                        |
-| ----------------------------------- | --------------------------------------------------------------------------- |
-| `service-json-keys/grpc`            | Private signing + key-management API. Internal network only.                |
-| `service-json-keys/rest`            | Public key-fetch + health API.                                              |
-| `service-json-keys/jobs/migrations` | One-shot schema migration job; runs to completion before the servers start. |
-| `service-json-keys/jobs/rotatekeys` | Scheduled key-rotation job (see [Configuration](#configuration)).           |
-| `service-json-keys/database`        | Pre-tuned PostgreSQL image — or bring your own Postgres.                    |
+| Image                               | Role                                                                             |
+| ----------------------------------- | -------------------------------------------------------------------------------- |
+| `service-json-keys/grpc`            | Private signing + key-management API. Internal network only.                     |
+| `service-json-keys/rest`            | Public key-fetch + health API.                                                   |
+| `service-json-keys/jobs/migrations` | One-shot schema migration job; runs to completion before the servers start.      |
+| `service-json-keys/jobs/rotatekeys` | Scheduled key-rotation job (see [CONTRIBUTING](./CONTRIBUTING.md#key-rotation)). |
+| `service-json-keys/database`        | Pre-tuned PostgreSQL image — or bring your own Postgres.                         |
 
 Pin every image to the same release tag — see the [latest release](https://github.com/a-novel/service-json-keys/releases/latest). A production deployment runs `database`, then the migrations job to completion, then any number of `grpc` and/or `rest` replicas:
 
@@ -57,7 +57,7 @@ services:
       - json-keys-postgres-data:/var/lib/postgresql/
 
   migrations-json-keys:
-    image: ghcr.io/a-novel/service-json-keys/jobs/migrations:v2.3.1
+    image: ghcr.io/a-novel/service-json-keys/jobs/migrations:v2.3.2
     depends_on:
       postgres-json-keys: { condition: service_healthy }
     environment:
@@ -65,7 +65,7 @@ services:
     networks: [api]
 
   service-json-keys:
-    image: ghcr.io/a-novel/service-json-keys/grpc:v2.3.2 # or .../rest:v2.3.1 for the public REST API
+    image: ghcr.io/a-novel/service-json-keys/grpc:v2.3.2 # or .../rest:v2.3.2 for the public REST API
     ports: ["${GRPC_PORT}:8080"] # the container always listens on 8080; map ${REST_PORT} for the rest image
     depends_on:
       postgres-json-keys: { condition: service_healthy }
@@ -170,7 +170,7 @@ func main() {
 	defer client.Close()
 
 	// Sign claims under the auth usage.
-	payload, err := grpcf.InterfaceToProtoAny(MyClaims{UserID: "user-1"})
+	payload, err := grpcf.MarshalJSONAsAny(MyClaims{UserID: "user-1"})
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/cmd/migrations/main.go
+++ b/cmd/migrations/main.go
@@ -23,11 +23,9 @@ func main() {
 
 	start := time.Now()
 
-	// Inventory the .up.sql files up-front so the recap can say how
-	// many migrations were discovered (the underlying helper uses
-	// uptrace/bun's Migrate, which doesn't expose a count without
-	// invasive wrapping — counting the embed.FS is the simplest
-	// stable approximation).
+	// Inventory the .up.sql files up front for the start-of-run log. The
+	// bun migrator doesn't expose a count, so the embedded FS is the closest
+	// stable source.
 	discovered := listUpMigrations(migrations.Migrations)
 	log.Printf("discovered %d migration(s) in models/migrations", len(discovered))
 
@@ -46,18 +44,17 @@ func main() {
 		len(discovered), time.Since(start).Round(time.Millisecond))
 }
 
-// listUpMigrations returns the bare names of every *.up.sql in the
-// migrations FS, sorted by their natural lexical order (timestamp
-// prefix guarantees chronological). Used for the start-of-run
-// inventory log; doesn't decide which are actually applied — bun's
-// migrator does that against the schema_migrations table.
+// listUpMigrations returns the bare name of every *.up.sql in the migrations
+// FS, in lexical order (the timestamp prefix makes that chronological). It
+// feeds the start-of-run inventory log only; bun's migrator decides which
+// migrations actually run.
 func listUpMigrations(f fs.FS) []string {
 	var out []string
 
 	_ = fs.WalkDir(f, ".", func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
-			// Propagating aborts the walk; the caller discards the error —
-			// the inventory is best-effort logging, not a gate.
+			// Aborts the walk on error; the caller discards it, since the
+			// inventory is best-effort logging rather than a gate.
 			return err
 		}
 

--- a/cmd/rotate-keys/main.go
+++ b/cmd/rotate-keys/main.go
@@ -85,9 +85,9 @@ func main() {
 
 	db := lo.Must(postgres.GetContext(ctx))
 
-	// CONCURRENTLY allows reads to continue during the refresh; requires the unique index
-	// on active_keys.id added by the 20260416000000_active_keys_unique_index migration.
-	// Must run outside any transaction block — postgres.RunInTx has already committed above.
+	// CONCURRENTLY lets reads continue during the refresh, but requires the unique index
+	// on active_keys.id and must run outside any transaction block — postgres.RunInTx has
+	// already committed above.
 	_, err = db.NewRaw("REFRESH MATERIALIZED VIEW CONCURRENTLY active_keys;").Exec(ctx)
 	if err != nil {
 		err = otel.ReportError(span, fmt.Errorf("rotate keys: %w", err))

--- a/internal/config/env/doc.go
+++ b/internal/config/env/doc.go
@@ -1,4 +1,5 @@
-// Package env loads and exposes application configuration from environment variables.
-// Each exported variable corresponds to an environment variable; defaults are applied
-// when the variable is absent or empty.
+// Package env reads the service configuration from environment variables and exposes
+// each setting as a package-level variable, resolved once at package initialization.
+// Settings that have a fallback apply their Default value when the variable is unset
+// or empty; the rest are used as read.
 package env

--- a/internal/config/jwks.config.yaml
+++ b/internal/config/jwks.config.yaml
@@ -8,7 +8,7 @@ auth:
   alg: EdDSA
   key:
     ttl: 168h # 7 days — how long a key version stays active before expiring
-    rotation: 24h # a new key is generated every 24 h; older keys remain active until their TTL
+    rotation: 24h # a new key is generated every 24h; older keys remain active until their TTL
     cache: 30m # how long public keys are cached locally before re-fetching
   token:
     ttl: 24h

--- a/internal/core/jwkGen.go
+++ b/internal/core/jwkGen.go
@@ -46,11 +46,11 @@ type JwkGenRequest struct {
 
 // A JwkGen generates new keys for a configured usage.
 //
-// It does not force the generation of a key. Instead, when called, it checks the
-// current state of the database to determine whether a new main key is needed.
+// It does not force generation. When called, it inspects the current state of the
+// database to decide whether the usage is due for a new key.
 //
-// If the main key for the target usage is recent enough, this service returns it
-// and skips generation. This is recorded in traces.
+// If the latest key for the usage is still within its rotation window, that key is
+// returned and generation is skipped; the skip is recorded on the trace span.
 type JwkGen struct {
 	daoSearch      JwkGenDaoSearch
 	daoInsert      JwkGenDaoInsert

--- a/internal/core/jwkSearch.go
+++ b/internal/core/jwkSearch.go
@@ -30,8 +30,9 @@ type JwkSearchRequest struct {
 	Private bool
 }
 
-// A JwkSearch lists the active keys for a given usage. Keys are returned in
-// creation order: the first element is the main key, the rest are legacy.
+// A JwkSearch lists the active keys for a given usage, newest first: the first
+// element is the current signing key and the rest are older keys still trusted
+// for verifying tokens issued before the last rotation.
 type JwkSearch struct {
 	dao            JwkSearchDao
 	serviceExtract JwkSearchServiceExtract

--- a/internal/dao/pg.jwkDelete.sql
+++ b/internal/dao/pg.jwkDelete.sql
@@ -1,7 +1,6 @@
 UPDATE keys
 SET
   deleted_at = ?0,
-  -- Premature revocation; the comment records the reason.
   deleted_comment = ?1
 WHERE
   id = ?2

--- a/internal/dao/pg.jwkSearch.go
+++ b/internal/dao/pg.jwkSearch.go
@@ -31,8 +31,8 @@ type JwkSearchRequest struct {
 	Usage string
 }
 
-// A PgJwkSearch lists the active keys for a given usage. Keys are returned in
-// creation order: the first element is the main key, the rest are legacy.
+// A PgJwkSearch lists the active keys for a given usage. Keys are returned
+// newest first: the first element is the main key, the rest are legacy.
 //
 // There is no pagination for this query; regular rotation and expiration keep
 // the active key count well below [KeysMaxBatchSize] under normal operation.

--- a/internal/handlers/doc.go
+++ b/internal/handlers/doc.go
@@ -6,7 +6,7 @@
 //   - gRPC handlers: the private API for authenticated service-to-service calls, covering
 //     token signing, key retrieval, and dependency health checks. Wired by cmd/grpc.
 //
-//   - REST handlers: the public, read-only API for token verification. It exposes the
+//   - REST handlers: the public, read-only API for token verification, exposing the
 //     JSON Web Keys without requiring authentication. Wired by cmd/rest.
 //
 // All handlers translate incoming requests into service-layer calls and map the results

--- a/internal/handlers/doc.go
+++ b/internal/handlers/doc.go
@@ -3,11 +3,11 @@
 //
 // There are two transport implementations, each serving a distinct audience:
 //
-//   - gRPC handlers: the private API for authenticated service-to-service calls. They
-//     cover token signing, key retrieval, and health checks. Wired by cmd/grpc.
+//   - gRPC handlers: the private API for authenticated service-to-service calls, covering
+//     token signing, key retrieval, and dependency health checks. Wired by cmd/grpc.
 //
-//   - REST handlers: the public read-only API for token verification. They expose
-//     JSON Web Key endpoints without requiring authentication. Wired by cmd/rest.
+//   - REST handlers: the public, read-only API for token verification. It exposes the
+//     JSON Web Keys without requiring authentication. Wired by cmd/rest.
 //
 // All handlers translate incoming requests into service-layer calls and map the results
 // back to protocol-level responses. They do not contain business logic.

--- a/internal/handlers/protogen/jwk.pb.go
+++ b/internal/handlers/protogen/jwk.pb.go
@@ -25,16 +25,16 @@ const (
 type Jwk struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Key type identifier. Corresponds to the "kty" JWK parameter (RFC 7517 §4.1).
-	// Identifies the cryptographic algorithm family (e.g., "OKP" for EdDSA, "RSA", "EC", "oct" for HMAC).
+	// Names the cryptographic algorithm family (e.g., "OKP" for an EdDSA key).
 	Kty string `protobuf:"bytes,1,opt,name=kty,proto3" json:"kty,omitempty"`
 	// Intended public key use. Corresponds to the "use" JWK parameter (RFC 7517 §4.2).
 	// Typically "sig" for signing keys used to produce or verify JWTs.
 	Use string `protobuf:"bytes,2,opt,name=use,proto3" json:"use,omitempty"`
 	// Permitted key operations. Corresponds to the "key_ops" JWK parameter (RFC 7517 §4.3).
-	// Common values are "sign" (private key) and "verify" (public key).
+	// A public verification key carries "verify".
 	KeyOps []string `protobuf:"bytes,3,rep,name=key_ops,json=keyOps,proto3" json:"key_ops,omitempty"`
 	// Algorithm. Corresponds to the "alg" JWK parameter (RFC 7517 §4.4).
-	// Identifies the specific signing algorithm (e.g., "EdDSA", "RS256", "ES384").
+	// Identifies the specific signing algorithm (e.g., "EdDSA").
 	Alg string `protobuf:"bytes,4,opt,name=alg,proto3" json:"alg,omitempty"`
 	// Key ID. Corresponds to the "kid" JWK parameter (RFC 7517 §4.5).
 	// Carried in the JWT header to identify which key was used to sign the token.

--- a/internal/handlers/protogen/jwk_list.pb.go
+++ b/internal/handlers/protogen/jwk_list.pb.go
@@ -70,7 +70,7 @@ func (x *JwkListRequest) GetUsage() string {
 // JwkListResponse contains the active public keys for the requested usage.
 type JwkListResponse struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// The active JSON Web Keys for the requested usage, in creation order.
+	// The active JSON Web Keys for the requested usage, newest first.
 	Keys          []*Jwk `protobuf:"bytes,1,rep,name=keys,proto3" json:"keys,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache

--- a/internal/handlers/protogen/jwk_list_grpc.pb.go
+++ b/internal/handlers/protogen/jwk_list_grpc.pb.go
@@ -26,11 +26,12 @@ const (
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
 //
-// JwkListService lists the active keys for a given usage. The keys are returned in
-// creation order (first key in the array is the main key, the rest are legacy).
+// JwkListService lists the active keys for a given usage, newest first: the first key is
+// the current signing key, the rest are older keys still trusted for verification.
 type JwkListServiceClient interface {
-	// Returns the active public keys for the given usage in creation order.
-	// The first key is the current main key; the rest are legacy keys not yet expired.
+	// Returns the active public keys for the given usage, newest first. The first key is the
+	// current signing key; the rest are older keys still trusted for verifying tokens issued
+	// before the last rotation.
 	JwkList(ctx context.Context, in *JwkListRequest, opts ...grpc.CallOption) (*JwkListResponse, error)
 }
 
@@ -56,11 +57,12 @@ func (c *jwkListServiceClient) JwkList(ctx context.Context, in *JwkListRequest, 
 // All implementations must embed UnimplementedJwkListServiceServer
 // for forward compatibility.
 //
-// JwkListService lists the active keys for a given usage. The keys are returned in
-// creation order (first key in the array is the main key, the rest are legacy).
+// JwkListService lists the active keys for a given usage, newest first: the first key is
+// the current signing key, the rest are older keys still trusted for verification.
 type JwkListServiceServer interface {
-	// Returns the active public keys for the given usage in creation order.
-	// The first key is the current main key; the rest are legacy keys not yet expired.
+	// Returns the active public keys for the given usage, newest first. The first key is the
+	// current signing key; the rest are older keys still trusted for verifying tokens issued
+	// before the last rotation.
 	JwkList(context.Context, *JwkListRequest) (*JwkListResponse, error)
 	mustEmbedUnimplementedJwkListServiceServer()
 }

--- a/internal/handlers/protogen/status.pb.go
+++ b/internal/handlers/protogen/status.pb.go
@@ -79,11 +79,10 @@ func (DependencyStatus) EnumDescriptor() ([]byte, []int) {
 
 // DependencyHealth reports the health of a single external dependency.
 //
-// The shape is deliberately minimal. Status endpoints are surfaced over an internal-only
-// gRPC API today, but errors raised while checking dependency health routinely embed
-// internal hostnames, ports, or schema names; carrying them in a public-shaped response
-// would leak infrastructure topology if this surface ever became externally reachable.
-// The underlying error is recorded on the trace span for operators instead.
+// The shape is deliberately minimal. This gRPC surface is internal today, but errors from a
+// dependency health check routinely embed internal hostnames, ports, or schema names, and
+// carrying them in the response would leak infrastructure topology if it ever became
+// externally reachable. The underlying error is recorded on the trace span for operators.
 type DependencyHealth struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// The dependency's current operational status.

--- a/internal/lib/masterKeyContext.go
+++ b/internal/lib/masterKeyContext.go
@@ -43,8 +43,7 @@ func NewMasterKeyContext(ctx context.Context, masterKeyRaw string) (context.Cont
 		))
 	}
 
-	// Convert the raw master key to a fixed 32-byte array.
-	// This is required for use with the secretbox package (see golang.org/x/crypto/nacl/secretbox).
+	// secretbox needs the key as a fixed-size array, not a slice.
 	var masterKey [MasterKeyLength]byte
 	copy(masterKey[:], masterKeyBytes)
 

--- a/internal/models/migrations/20250113182800_keys_table.up.sql
+++ b/internal/models/migrations/20250113182800_keys_table.up.sql
@@ -4,7 +4,7 @@ CREATE TABLE keys (
   private_key text NOT NULL CHECK (private_key <> ''),
   /* Public key in JSON Web Key format, base64url-encoded. Null for symmetric keys. */
   public_key text,
-  /* Groups keys that serve the same signing purpose (e.g., "auth", "auth-refresh"). */
+  /* Groups keys that serve the same purpose (e.g., "auth"). */
   usage text NOT NULL,
   created_at timestamp(0) with time zone NOT NULL,
   /* Hard expiry date. Once passed, the key is excluded from the active view. */
@@ -17,8 +17,8 @@ CREATE TABLE keys (
 
 CREATE INDEX keys_usage_idx ON keys (usage);
 
-/* active_keys exposes only keys that have not yet expired and have not been soft-deleted.
-A key is considered active when deleted_at is null (or in the future) AND expires_at is in the future. */
+/* active_keys exposes only keys that are still valid. A key stays visible until its cutoff
+passes: deleted_at when the key has been revoked early, otherwise expires_at. */
 CREATE VIEW active_keys AS (
   SELECT
     *

--- a/internal/models/proto/jwk.proto
+++ b/internal/models/proto/jwk.proto
@@ -3,16 +3,16 @@ syntax = "proto3";
 // Jwk represents a public JSON Web Key. Private key material is never included.
 message Jwk {
   // Key type identifier. Corresponds to the "kty" JWK parameter (RFC 7517 §4.1).
-  // Identifies the cryptographic algorithm family (e.g., "OKP" for EdDSA, "RSA", "EC", "oct" for HMAC).
+  // Names the cryptographic algorithm family (e.g., "OKP" for an EdDSA key).
   string kty = 1;
   // Intended public key use. Corresponds to the "use" JWK parameter (RFC 7517 §4.2).
   // Typically "sig" for signing keys used to produce or verify JWTs.
   string use = 2;
   // Permitted key operations. Corresponds to the "key_ops" JWK parameter (RFC 7517 §4.3).
-  // Common values are "sign" (private key) and "verify" (public key).
+  // A public verification key carries "verify".
   repeated string key_ops = 3;
   // Algorithm. Corresponds to the "alg" JWK parameter (RFC 7517 §4.4).
-  // Identifies the specific signing algorithm (e.g., "EdDSA", "RS256", "ES384").
+  // Identifies the specific signing algorithm (e.g., "EdDSA").
   string alg = 4;
   // Key ID. Corresponds to the "kid" JWK parameter (RFC 7517 §4.5).
   // Carried in the JWT header to identify which key was used to sign the token.

--- a/internal/models/proto/jwk_list.proto
+++ b/internal/models/proto/jwk_list.proto
@@ -2,11 +2,12 @@ syntax = "proto3";
 
 import "jwk.proto";
 
-// JwkListService lists the active keys for a given usage. The keys are returned in
-// creation order (first key in the array is the main key, the rest are legacy).
+// JwkListService lists the active keys for a given usage, newest first: the first key is
+// the current signing key, the rest are older keys still trusted for verification.
 service JwkListService {
-  // Returns the active public keys for the given usage in creation order.
-  // The first key is the current main key; the rest are legacy keys not yet expired.
+  // Returns the active public keys for the given usage, newest first. The first key is the
+  // current signing key; the rest are older keys still trusted for verifying tokens issued
+  // before the last rotation.
   rpc JwkList(JwkListRequest) returns (JwkListResponse);
 }
 
@@ -18,6 +19,6 @@ message JwkListRequest {
 
 // JwkListResponse contains the active public keys for the requested usage.
 message JwkListResponse {
-  // The active JSON Web Keys for the requested usage, in creation order.
+  // The active JSON Web Keys for the requested usage, newest first.
   repeated Jwk keys = 1;
 }

--- a/internal/models/proto/status.proto
+++ b/internal/models/proto/status.proto
@@ -21,16 +21,13 @@ enum DependencyStatus {
 
 // DependencyHealth reports the health of a single external dependency.
 //
-// The shape is deliberately minimal. Status endpoints are surfaced over an internal-only
-// gRPC API today, but errors raised while checking dependency health routinely embed
-// internal hostnames, ports, or schema names; carrying them in a public-shaped response
-// would leak infrastructure topology if this surface ever became externally reachable.
-// The underlying error is recorded on the trace span for operators instead.
+// The shape is deliberately minimal. This gRPC surface is internal today, but errors from a
+// dependency health check routinely embed internal hostnames, ports, or schema names, and
+// carrying them in the response would leak infrastructure topology if it ever became
+// externally reachable. The underlying error is recorded on the trace span for operators.
 message DependencyHealth {
-  // Field number 2 / name "err" was used for an error string; it was removed because raw
-  // dependency errors leak infrastructure topology (see message-level comment above). The
-  // number and name are reserved so a future field cannot accidentally re-introduce the leak
-  // with a different shape on the wire.
+  // Number 2 and name "err" are reserved so a future field cannot re-introduce a raw error
+  // string, which would re-open the topology leak this message is shaped to avoid.
   reserved 2;
   reserved "err";
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -37,8 +37,7 @@ paths:
       description: |
         A simple endpoint to check if the server is up and running. It always returns the same response.
 
-        Note this **DOES NOT** give information about the server dependencies. To get more information about the
-        server actual health, please use the `/healthcheck` endpoint.
+        This does not report on the server's dependencies; use the `/healthcheck` endpoint for that.
       tags: [health]
       security: []
       responses:

--- a/pkg/go/client.go
+++ b/pkg/go/client.go
@@ -29,8 +29,8 @@ type (
 	// JwkRecipients holds the per-usage JWT verification plugins.
 	// Retrieved via [Client.Recipients].
 	JwkRecipients = core.JwkRecipients
-	// JwkConfig holds the full configuration for a single key usage: signing algorithm,
-	// key lifetime and caching parameters, and JWT token claim parameters.
+	// JwkConfig holds the full configuration for a single key usage — the signing algorithm
+	// and the key and token parameters applied to every JWT signed under it.
 	// Keyed by usage name in the map returned by [Client.Keys].
 	JwkConfig = config.Jwk
 )

--- a/pkg/js/rest/src/api.ts
+++ b/pkg/js/rest/src/api.ts
@@ -46,8 +46,8 @@ export class JsonKeysApi {
 
   /**
    * Returns the health status of every service dependency, keyed by dependency name.
-   * The server always responds with 200; inspect each entry's `status` field to detect
-   * degraded dependencies.
+   * The endpoint always responds 200; a degraded dependency shows as a `down` entry,
+   * so inspect each entry's `status` field to detect one.
    */
   async health(): Promise<Record<string, HealthDependency>> {
     return await this.fetch("/healthcheck", { method: "GET" });


### PR DESCRIPTION
## Summary

- Sweeps in-code comments and project docs (`README`, `openapi.yaml` descriptions) against the sharpened documentation contract: **rationale over restatement**, plain voice, and comments paced as navigation rather than per line.
- Fixes several claims that had drifted from the code:
  - `JwkSearch` / `PgJwkSearch` said keys come back "in creation order" — the query sorts `created_at DESC` (newest first).
  - `internal/config/env` package doc claimed defaults apply to every variable; several have no fallback.
  - `JwkGen` referenced a non-existent "main key" concept.
  - The README Go client example called `grpcf.InterfaceToProtoAny`, renamed to `grpcf.MarshalJSONAsAny` (`golib/grpcf/any.go`).
  - Normalized the compose block to a single release tag per the README's own rule; de-jargoned the `/ping` OpenAPI description.

## Scope

Comments and documentation only — **no code changed** (verified: no non-comment line differs in any `.go`/`.ts`/`.proto` file). `.github/**` (managed by `a-novel repo update`) and `builds/**` were left untouched.

## Test plan

- [x] `pnpm run format` is a no-op (already formatted)
- [x] Comments-only gate passes
- [ ] CI green