### PR TITLE
perf(ci): adopt gha docker build cache (workflows v1.15.6)

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: go generate
         shell: bash
         run: go generate ./...
-      - uses: a-novel-kit/workflows/generic-actions/check-changes@v1.15.4
+      - uses: a-novel-kit/workflows/generic-actions/check-changes@v1.15.6
         with:
           fail_message: go generate definitions are not up-to-date, please run 'go generate ./...' and commit the changes
 
@@ -30,7 +30,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: a-novel-kit/workflows/go-actions/lint-go@v1.15.4
+      - uses: a-novel-kit/workflows/go-actions/lint-go@v1.15.6
 
   lint-proto:
     runs-on: ubuntu-latest
@@ -46,7 +46,7 @@ jobs:
       contents: read
       packages: read
     steps:
-      - uses: a-novel-kit/workflows/node-actions/lint-node@v1.15.4
+      - uses: a-novel-kit/workflows/node-actions/lint-node@v1.15.6
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           app_private_key: ${{ secrets.DEPENDENCY_BOT_PRIVATE_KEY }}
@@ -82,7 +82,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/run-migrations
-      - uses: a-novel-kit/workflows/go-actions/test-go@v1.15.4
+      - uses: a-novel-kit/workflows/go-actions/test-go@v1.15.6
         id: test
         with:
           filter_extra_patterns: "| grep /internal | grep -v /protogen"
@@ -130,7 +130,7 @@ jobs:
       GRPC_URL: "localhost:8080"
     steps:
       - uses: actions/checkout@v7
-      - uses: a-novel-kit/workflows/go-actions/test-go@v1.15.4
+      - uses: a-novel-kit/workflows/go-actions/test-go@v1.15.6
         id: test
         with:
           filter_extra_patterns: "| grep /pkg"
@@ -178,7 +178,7 @@ jobs:
     env:
       REST_URL: "http://localhost:8080"
     steps:
-      - uses: a-novel-kit/workflows/node-actions/test-node@v1.15.4
+      - uses: a-novel-kit/workflows/node-actions/test-node@v1.15.6
         id: test
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -203,11 +203,12 @@ jobs:
       POSTGRES_HOST_AUTH_METHOD: scram-sha-256
       POSTGRES_INITDB_ARGS: --auth=scram-sha-256
     steps:
-      - uses: a-novel-kit/workflows/build-actions/docker@v1.15.4
+      - uses: a-novel-kit/workflows/build-actions/docker@v1.15.6
         id: build
         with:
           file: builds/database.Dockerfile
           image_name: ${{ github.repository }}/database
+          cache: false
           github_token: ${{ secrets.GITHUB_TOKEN }}
           run_args: >-
             -e POSTGRES_PASSWORD="${POSTGRES_PASSWORD}" 
@@ -243,7 +244,7 @@ jobs:
     env:
       POSTGRES_DSN: postgres://postgres:postgres@localhost:5432/postgres?sslmode=disable
     steps:
-      - uses: a-novel-kit/workflows/build-actions/docker-job@v1.15.4
+      - uses: a-novel-kit/workflows/build-actions/docker-job@v1.15.6
         with:
           file: builds/migrations.Dockerfile
           image_name: ${{ github.repository }}/jobs/migrations
@@ -280,7 +281,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/run-migrations
-      - uses: a-novel-kit/workflows/build-actions/docker-job@v1.15.4
+      - uses: a-novel-kit/workflows/build-actions/docker-job@v1.15.6
         with:
           file: builds/rotate-keys.Dockerfile
           image_name: ${{ github.repository }}/jobs/rotatekeys
@@ -317,7 +318,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/run-migrations
-      - uses: a-novel-kit/workflows/build-actions/docker@v1.15.4
+      - uses: a-novel-kit/workflows/build-actions/docker@v1.15.6
         with:
           file: builds/grpc.Dockerfile
           image_name: ${{ github.repository }}/grpc
@@ -356,7 +357,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/run-migrations
-      - uses: a-novel-kit/workflows/build-actions/docker@v1.15.4
+      - uses: a-novel-kit/workflows/build-actions/docker@v1.15.6
         id: build
         with:
           file: builds/standalone.grpc.Dockerfile
@@ -394,7 +395,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/run-migrations
-      - uses: a-novel-kit/workflows/build-actions/docker@v1.15.4
+      - uses: a-novel-kit/workflows/build-actions/docker@v1.15.6
         with:
           file: builds/rest.Dockerfile
           image_name: ${{ github.repository }}/rest
@@ -433,7 +434,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/run-migrations
-      - uses: a-novel-kit/workflows/build-actions/docker@v1.15.4
+      - uses: a-novel-kit/workflows/build-actions/docker@v1.15.6
         id: build
         with:
           file: builds/standalone.rest.Dockerfile
@@ -448,7 +449,7 @@ jobs:
       contents: read
       packages: read
     steps:
-      - uses: a-novel-kit/workflows/node-actions/build-node@v1.15.4
+      - uses: a-novel-kit/workflows/node-actions/build-node@v1.15.6
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           app_private_key: ${{ secrets.DEPENDENCY_BOT_PRIVATE_KEY }}
@@ -462,7 +463,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: a-novel-kit/workflows/go-actions/go-report-card@v1.15.4
+      - uses: a-novel-kit/workflows/go-actions/go-report-card@v1.15.6
         if: github.ref == 'refs/heads/master' && success()
 
   report-codecov:
@@ -471,7 +472,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: a-novel-kit/workflows/generic-actions/codecov@v1.15.4
+      - uses: a-novel-kit/workflows/generic-actions/codecov@v1.15.6
         with:
           codecov_token: ${{ secrets.CODECOV_TOKEN }}
           coverage_files: coverage.txt,coverage_pkg.txt,coverage/*

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -48,7 +48,7 @@ jobs:
       tag: ${{ steps.core.outputs.tag }}
     steps:
       - id: core
-        uses: a-novel-kit/workflows/publish-actions/release-core@v1.15.4
+        uses: a-novel-kit/workflows/publish-actions/release-core@v1.15.6
         with:
           release_type: ${{ inputs.release_type }}
           dry_run: ${{ inputs.dry_run }}
@@ -71,10 +71,11 @@ jobs:
       POSTGRES_HOST_AUTH_METHOD: scram-sha-256
       POSTGRES_INITDB_ARGS: --auth=scram-sha-256
     steps:
-      - uses: a-novel-kit/workflows/build-actions/docker@v1.15.4
+      - uses: a-novel-kit/workflows/build-actions/docker@v1.15.6
         with:
           file: builds/database.Dockerfile
           image_name: ${{ github.repository }}/database
+          cache: false
           version: ${{ needs.release.outputs.version }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           run_args: >-
@@ -112,7 +113,7 @@ jobs:
     env:
       POSTGRES_DSN: postgres://postgres:postgres@localhost:5432/postgres?sslmode=disable
     steps:
-      - uses: a-novel-kit/workflows/build-actions/docker-job@v1.15.4
+      - uses: a-novel-kit/workflows/build-actions/docker-job@v1.15.6
         with:
           file: builds/migrations.Dockerfile
           image_name: ${{ github.repository }}/jobs/migrations
@@ -151,7 +152,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/run-migrations
-      - uses: a-novel-kit/workflows/build-actions/docker-job@v1.15.4
+      - uses: a-novel-kit/workflows/build-actions/docker-job@v1.15.6
         with:
           file: builds/rotate-keys.Dockerfile
           image_name: ${{ github.repository }}/jobs/rotatekeys
@@ -190,7 +191,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/run-migrations
-      - uses: a-novel-kit/workflows/build-actions/docker@v1.15.4
+      - uses: a-novel-kit/workflows/build-actions/docker@v1.15.6
         with:
           file: builds/grpc.Dockerfile
           image_name: ${{ github.repository }}/grpc
@@ -229,7 +230,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/run-migrations
-      - uses: a-novel-kit/workflows/build-actions/docker@v1.15.4
+      - uses: a-novel-kit/workflows/build-actions/docker@v1.15.6
         with:
           file: builds/standalone.grpc.Dockerfile
           image_name: ${{ github.repository }}/standalone-grpc
@@ -268,7 +269,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/run-migrations
-      - uses: a-novel-kit/workflows/build-actions/docker@v1.15.4
+      - uses: a-novel-kit/workflows/build-actions/docker@v1.15.6
         with:
           file: builds/rest.Dockerfile
           image_name: ${{ github.repository }}/rest
@@ -307,7 +308,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/run-migrations
-      - uses: a-novel-kit/workflows/build-actions/docker@v1.15.4
+      - uses: a-novel-kit/workflows/build-actions/docker@v1.15.6
         with:
           file: builds/standalone.rest.Dockerfile
           image_name: ${{ github.repository }}/standalone-rest
@@ -325,7 +326,7 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: a-novel-kit/workflows/publish-actions/npm@v1.15.4
+      - uses: a-novel-kit/workflows/publish-actions/npm@v1.15.6
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           app_private_key: ${{ secrets.PUBLISH_BOT_PRIVATE_KEY }}
@@ -349,7 +350,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: a-novel-kit/workflows/generic-actions/archive-board-items@v1.15.4
+      - uses: a-novel-kit/workflows/generic-actions/archive-board-items@v1.15.6
         with:
           client_id: ${{ vars.AGENT_BOT_CLIENT_ID }}
           app_private_key: ${{ secrets.AGENT_BOT_PRIVATE_KEY }}


### PR DESCRIPTION
## Summary

Adopts the cross-run Docker build cache shipped in `a-novel-kit/workflows` v1.15.6 (keystone a-novel-kit/workflows#280):

- Bumps the `a-novel-kit/workflows` pin `v1.15.4 → v1.15.6` (adds `type=gha,mode=max` layer cache, scoped per image).
- Passes `cache: false` on the postgres `build-database` job (`main.yaml` + `release.yaml`) — caching its large base to GHA is a net loss and it gates the test job on the critical path.

**Note (json-keys):** the database image compiles `pg_cron`, but the ~150MB postgres base dominates the cache export cost while the pg_cron compile saving is negligible, so `cache: false` is still the right call. Could be re-measured later if we want to squeeze it.

Part of the **Build & CI performance** Initiative (a-novel/.github#172), Epic a-novel/.github#173. Benchmarked on service-authentication: ~−30% total wall-clock warm, Go image builds −36% to −64%.

## Breaking changes

None. Additive CI-only change.

## Test plan

- [ ] main CI green (first run populates the cache; subsequent runs are warm)