### PR TITLE
perf(builds): add BuildKit cache mounts to builder images

### DIFF
--- a/builds/grpc.Dockerfile
+++ b/builds/grpc.Dockerfile
@@ -10,11 +10,14 @@ WORKDIR /app
 # Download dependencies before copying source files so the module cache layer is
 # reused on rebuilds where only source files change.
 COPY go.mod go.sum ./
-RUN go mod download
+RUN --mount=type=cache,target=/go/pkg/mod \
+    go mod download
 
 # Install grpcurl for the healthcheck. Placed before source COPY so the cached
 # layer (download + compile) survives source-only rebuilds.
-RUN GOBIN=/usr/local/bin go install github.com/fullstorydev/grpcurl/cmd/grpcurl@v1.9.3
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    GOBIN=/usr/local/bin go install github.com/fullstorydev/grpcurl/cmd/grpcurl@v1.9.3
 
 COPY ./cmd/grpc ./cmd/grpc
 COPY ./internal/handlers ./internal/handlers
@@ -26,7 +29,9 @@ COPY ./internal/config ./internal/config
 
 # -ldflags="-s -w" strips the symbol table and DWARF debug info, shrinking the binary.
 # -trimpath removes local filesystem paths for reproducible builds.
-RUN go build -ldflags="-s -w" -trimpath -o /grpc ./cmd/grpc/
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    go build -ldflags="-s -w" -trimpath -o /grpc ./cmd/grpc/
 
 FROM docker.io/library/alpine:3.24.1
 

--- a/builds/migrations.Dockerfile
+++ b/builds/migrations.Dockerfile
@@ -6,13 +6,16 @@ ENV CGO_ENABLED=0
 WORKDIR /app
 
 COPY go.mod go.sum ./
-RUN go mod download
+RUN --mount=type=cache,target=/go/pkg/mod \
+    go mod download
 
 COPY ./cmd/migrations ./cmd/migrations
 COPY ./internal/config ./internal/config
 COPY ./internal/models/migrations ./internal/models/migrations
 
-RUN go build -ldflags="-s -w" -trimpath -o /migrations ./cmd/migrations/
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    go build -ldflags="-s -w" -trimpath -o /migrations ./cmd/migrations/
 
 FROM docker.io/library/alpine:3.24.1
 

--- a/builds/rest.Dockerfile
+++ b/builds/rest.Dockerfile
@@ -6,7 +6,8 @@ ENV CGO_ENABLED=0
 WORKDIR /app
 
 COPY go.mod go.sum ./
-RUN go mod download
+RUN --mount=type=cache,target=/go/pkg/mod \
+    go mod download
 
 COPY ./cmd/rest ./cmd/rest
 COPY ./internal/handlers ./internal/handlers
@@ -16,7 +17,9 @@ COPY ./internal/core ./internal/core
 COPY ./internal/models ./internal/models
 COPY ./internal/config ./internal/config
 
-RUN go build -ldflags="-s -w" -trimpath -o /rest ./cmd/rest/
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    go build -ldflags="-s -w" -trimpath -o /rest ./cmd/rest/
 
 FROM docker.io/library/alpine:3.24.1
 

--- a/builds/rotate-keys.Dockerfile
+++ b/builds/rotate-keys.Dockerfile
@@ -8,7 +8,8 @@ ENV CGO_ENABLED=0
 WORKDIR /app
 
 COPY go.mod go.sum ./
-RUN go mod download
+RUN --mount=type=cache,target=/go/pkg/mod \
+    go mod download
 
 COPY ./cmd/rotate-keys ./cmd/rotate-keys
 COPY ./internal/config ./internal/config
@@ -16,7 +17,9 @@ COPY ./internal/dao ./internal/dao
 COPY ./internal/core ./internal/core
 COPY ./internal/lib ./internal/lib
 
-RUN go build -ldflags="-s -w" -trimpath -o /rotate-keys ./cmd/rotate-keys/
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    go build -ldflags="-s -w" -trimpath -o /rotate-keys ./cmd/rotate-keys/
 
 FROM docker.io/library/alpine:3.24.1
 

--- a/builds/standalone.grpc.Dockerfile
+++ b/builds/standalone.grpc.Dockerfile
@@ -8,9 +8,12 @@ ENV CGO_ENABLED=0
 WORKDIR /app
 
 COPY go.mod go.sum ./
-RUN go mod download
+RUN --mount=type=cache,target=/go/pkg/mod \
+    go mod download
 
-RUN GOBIN=/usr/local/bin go install github.com/fullstorydev/grpcurl/cmd/grpcurl@v1.9.3
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    GOBIN=/usr/local/bin go install github.com/fullstorydev/grpcurl/cmd/grpcurl@v1.9.3
 
 COPY ./cmd/grpc ./cmd/grpc
 COPY ./cmd/migrations ./cmd/migrations
@@ -22,7 +25,9 @@ COPY ./internal/core ./internal/core
 COPY ./internal/models ./internal/models
 COPY ./internal/config ./internal/config
 
-RUN go build -ldflags="-s -w" -trimpath -o /grpc ./cmd/grpc/ && \
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    go build -ldflags="-s -w" -trimpath -o /grpc ./cmd/grpc/ && \
     go build -ldflags="-s -w" -trimpath -o /migrations ./cmd/migrations/ && \
     go build -ldflags="-s -w" -trimpath -o /rotate-keys ./cmd/rotate-keys/
 

--- a/builds/standalone.rest.Dockerfile
+++ b/builds/standalone.rest.Dockerfile
@@ -8,7 +8,8 @@ ENV CGO_ENABLED=0
 WORKDIR /app
 
 COPY go.mod go.sum ./
-RUN go mod download
+RUN --mount=type=cache,target=/go/pkg/mod \
+    go mod download
 
 COPY ./cmd/rest ./cmd/rest
 COPY ./cmd/migrations ./cmd/migrations
@@ -20,7 +21,9 @@ COPY ./internal/core ./internal/core
 COPY ./internal/models ./internal/models
 COPY ./internal/config ./internal/config
 
-RUN go build -ldflags="-s -w" -trimpath -o /rest ./cmd/rest/ && \
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    go build -ldflags="-s -w" -trimpath -o /rest ./cmd/rest/ && \
     go build -ldflags="-s -w" -trimpath -o /migrations ./cmd/migrations/ && \
     go build -ldflags="-s -w" -trimpath -o /rotate-keys ./cmd/rotate-keys/
 


### PR DESCRIPTION
## Summary

Adds BuildKit cache mounts (`/go/pkg/mod` + `/root/.cache/go-build`) to the `go mod download`, `grpcurl` install, and `go build` steps of all six builder images. json-keys already had the modern Dockerfile shape (static/stripped binaries, correct layer order, busybox healthcheck, comprehensive `.dockerignore`), so this is the one remaining gap: cross-build cache reuse.

The local-dev half of the "cache the Docker build" root fix — a rebuild reuses the previous compilation instead of building cold. Verified locally (rest image builds clean). In CI the mount starts empty each run, so the gha layer cache (v1.15.6+) does the cross-run work — the two are complementary.

Closes #781. Part of Epic a-novel/.github#173 (a-novel/.github#172).

## Layers changed

- **builds**: cache mounts on all 6 Go builders. No shape/behaviour change (json-keys was already modern).

## Breaking changes

None.

## Test plan

- [ ] CI `build-*` jobs build and report healthy
- [x] Local: `rest` image builds with the cache mounts