### PR TITLE
fix(migrations): revert active_keys to a plain view so expiry and revocation apply

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,7 +72,7 @@ The `keys` table — defined in [`internal/models/migrations/`](./internal/model
 | `expires_at`                    | Hard expiry; the key leaves the active view at this point.         |
 | `deleted_at`, `deleted_comment` | Premature revocation (e.g., compromise). `nil` for natural expiry. |
 
-Reads target the `active_keys` materialized view, which excludes expired and soft-deleted rows. The view is refreshed by the rotation job after a write so consumers see the new main key on their next fetch.
+Reads target the `active_keys` view, which excludes expired and revoked rows. It is a plain view, so both predicates are evaluated per query — a key stops being served the moment its `expires_at` passes or its `deleted_at` is set, with no refresh step in between.
 
 ### Key configuration
 
@@ -97,7 +97,7 @@ Adding a usage means updating [`internal/config/jwks.config.yaml`](./internal/co
 
 ### Key rotation
 
-[`cmd/rotate-keys/main.go`](./cmd/rotate-keys/main.go) is a one-shot job. For each configured usage, it generates a new key when the current main key is older than `key.rotation`, then refreshes the `active_keys` materialized view so consumers see the change immediately. Run it on a schedule (cron, Kubernetes CronJob, etc.).
+[`cmd/rotate-keys/main.go`](./cmd/rotate-keys/main.go) is a one-shot job. For each configured usage, it generates a new key when the current main key is older than `key.rotation`, which consumers see on their next fetch. Run it on a schedule (cron, Kubernetes CronJob, etc.).
 
 This job is **not optional** for a long-running deployment. Existing keys age out of `active_keys` once they reach `key.ttl`, but nothing inside the gRPC or REST processes generates replacements — so without the job firing on schedule, the active set eventually empties for each usage and signing breaks. Run the job once during deploy/bootstrap as well so the database is seeded before the service is expected to sign anything; otherwise it starts with no keys to sign with. Standalone images do this automatically before starting the server (see `builds/standalone.*.Dockerfile`), but split gRPC/REST deployments must arrange that initial run themselves.
 

--- a/cmd/rotate-keys/main.go
+++ b/cmd/rotate-keys/main.go
@@ -1,6 +1,6 @@
 // Command rotate-keys rotates active JSON Web Keys. For each configured usage, it generates
-// a new key if the rotation interval has elapsed, then refreshes the active_keys materialized
-// view so consumers see the updated set immediately.
+// a new key if the rotation interval has elapsed. Consumers see it on their next fetch:
+// active_keys is a plain view, so there is no snapshot to refresh.
 //
 // Designed to run as a periodic job (e.g., a Kubernetes CronJob).
 package main
@@ -80,19 +80,8 @@ func main() {
 		log.Fatalln(err.Error()) //nolint:gocritic
 	}
 
-	// --- Refresh the materialized view so consumers see the updated active keys ---
-	log.Println("refreshing active_keys materialized view...")
-
-	db := lo.Must(postgres.GetContext(ctx))
-
-	// CONCURRENTLY lets reads continue during the refresh, but requires the unique index
-	// on active_keys.id and must run outside any transaction block — postgres.RunInTx has
-	// already committed above.
-	_, err = db.NewRaw("REFRESH MATERIALIZED VIEW CONCURRENTLY active_keys;").Exec(ctx)
-	if err != nil {
-		err = otel.ReportError(span, fmt.Errorf("rotate keys: %w", err))
-		log.Fatalln(err.Error())
-	}
+	// active_keys is a plain view, so a newly inserted key is visible to the next reader
+	// with no refresh step to run — and none to forget.
 
 	otel.ReportSuccessNoContent(span)
 	log.Printf("done — %d usage(s) processed, completed in %s",

--- a/internal/dao/migrations_test.go
+++ b/internal/dao/migrations_test.go
@@ -18,11 +18,11 @@ import (
 // `cron` schema and migration 20250713173700 (`cron.schedule(...)` for the
 // hourly active_keys refresh) would fail with `schema "cron" does not exist`.
 //
-// The scheduled job is irrelevant to tests anyway: it never fires during a test
-// run, and every DAO test that needs a current active_keys materialized view
-// already issues `REFRESH MATERIALIZED VIEW active_keys` itself. So a stub whose
-// schedule/unschedule are no-ops is functionally complete — it only has to let
-// the migration apply.
+// The scheduled job is irrelevant to tests: it never fires during a test run, and
+// active_keys is a plain view again, so there is no snapshot for it to maintain.
+// Both the migration that schedules the job and the later one that unschedules it
+// still run as history, so the stub covers schedule and unschedule alike. No-ops
+// are functionally complete — the stub only has to let those migrations apply.
 const (
 	cronStubUp = `CREATE SCHEMA IF NOT EXISTS cron;
 

--- a/internal/dao/pg.jwkDelete_test.go
+++ b/internal/dao/pg.jwkDelete_test.go
@@ -177,9 +177,6 @@ func TestPgJwkDelete(t *testing.T) {
 						require.NoError(t, err)
 					}
 
-					_, err = db.NewRaw("REFRESH MATERIALIZED VIEW active_keys;").Exec(ctx)
-					require.NoError(t, err)
-
 					key, err := dao.Exec(ctx, testCase.request)
 					require.ErrorIs(t, err, testCase.expectErr)
 					require.Equal(t, testCase.expect, key)
@@ -187,4 +184,62 @@ func TestPgJwkDelete(t *testing.T) {
 			)
 		})
 	}
+}
+
+// TestPgJwkDeleteTakesEffectImmediately is the regression this milestone's issue is about: a
+// revoked key must stop being served from the moment it is revoked, with no refresh in between.
+//
+// It reads through PgJwkSelect rather than asserting on the delete's own return value, because
+// the defect lived entirely on the read path. While active_keys was a materialized view the
+// snapshot carried a *copy* of deleted_at, so the revoked key kept being returned — and kept
+// signing — until the next hourly refresh. Nothing the reader could filter on would have caught
+// it, since the stale column was in the snapshot itself.
+func TestPgJwkDeleteTakesEffectImmediately(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now().UTC().Round(time.Second)
+	keyID := uuid.MustParse("00000000-0000-0000-0000-000000000001")
+
+	postgres.RunDBTest(
+		t,
+		configtest.PostgresPreset,
+		migrationsWithCronStub(t),
+		func(ctx context.Context, t *testing.T) {
+			t.Helper()
+
+			db, err := postgres.GetContext(ctx)
+			require.NoError(t, err)
+
+			fixture := &dao.Jwk{
+				ID:         keyID,
+				PrivateKey: "private-key",
+				PublicKey:  lo.ToPtr("public-key"),
+				Usage:      "auth",
+				CreatedAt:  now.Add(-time.Hour),
+				ExpiresAt:  now.Add(time.Hour),
+			}
+
+			_, err = db.NewInsert().Model(fixture).Exec(ctx)
+			require.NoError(t, err)
+
+			selectDAO := dao.NewPgJwkSelect()
+
+			// Precondition: the key is served before revocation. Without this the test would
+			// still pass against a read path that returns nothing at all.
+			got, err := selectDAO.Exec(ctx, &dao.JwkSelectRequest{ID: keyID})
+			require.NoError(t, err)
+			require.Equal(t, keyID, got.ID)
+
+			_, err = dao.NewPgJwkDelete().Exec(ctx, &dao.JwkDeleteRequest{
+				ID:      keyID,
+				Now:     now,
+				Comment: "compromised",
+			})
+			require.NoError(t, err)
+
+			// No refresh here on purpose — that is the whole assertion.
+			_, err = selectDAO.Exec(ctx, &dao.JwkSelectRequest{ID: keyID})
+			require.ErrorIs(t, err, dao.ErrJwkSelectNotFound)
+		},
+	)
 }

--- a/internal/dao/pg.jwkSearch_test.go
+++ b/internal/dao/pg.jwkSearch_test.go
@@ -179,9 +179,6 @@ func TestPgJwkSearch(t *testing.T) {
 						require.NoError(t, err)
 					}
 
-					_, err = db.NewRaw("REFRESH MATERIALIZED VIEW active_keys;").Exec(ctx)
-					require.NoError(t, err)
-
 					key, err := dao.Exec(ctx, testCase.request)
 					require.ErrorIs(t, err, testCase.expectErr)
 					require.Equal(t, testCase.expect, key)

--- a/internal/dao/pg.jwkSelect_test.go
+++ b/internal/dao/pg.jwkSelect_test.go
@@ -137,9 +137,6 @@ func TestPgJwkSelect(t *testing.T) {
 						require.NoError(t, err)
 					}
 
-					_, err = db.NewRaw("REFRESH MATERIALIZED VIEW active_keys;").Exec(ctx)
-					require.NoError(t, err)
-
 					key, err := dao.Exec(ctx, testCase.request)
 					require.ErrorIs(t, err, testCase.expectErr)
 					require.Equal(t, testCase.expect, key)

--- a/internal/models/migrations/20260722065917_active_keys_live_view.down.sql
+++ b/internal/models/migrations/20260722065917_active_keys_live_view.down.sql
@@ -1,0 +1,35 @@
+-- Restores the materialized view, its indexes and the hourly refresh job.
+--
+-- Reverting reinstates the staleness this migration removed: expiry and revocation stop taking
+-- effect until the next refresh.
+DROP VIEW IF EXISTS active_keys;
+
+CREATE MATERIALIZED VIEW active_keys AS (
+  SELECT
+    *
+  FROM
+    keys
+  WHERE
+    expires_at > CURRENT_TIMESTAMP
+    AND (
+      deleted_at IS NULL
+      OR deleted_at > CURRENT_TIMESTAMP
+    )
+);
+
+CREATE INDEX active_keys_usage_idx ON active_keys (usage);
+
+-- Required by REFRESH MATERIALIZED VIEW CONCURRENTLY.
+CREATE UNIQUE INDEX active_keys_id_idx ON active_keys (id);
+
+--bun:split
+-- Populate before scheduling, so the first reader does not see an empty view.
+REFRESH MATERIALIZED VIEW active_keys;
+
+--bun:split
+SELECT
+  cron.schedule (
+    'refresh-active-keys',
+    '0 * * * *',
+    $$REFRESH MATERIALIZED VIEW CONCURRENTLY active_keys;$$
+  );

--- a/internal/models/migrations/20260722065917_active_keys_live_view.up.sql
+++ b/internal/models/migrations/20260722065917_active_keys_live_view.up.sql
@@ -1,0 +1,33 @@
+-- Reverts active_keys to a plain view so its predicates are evaluated per query.
+--
+-- As a materialized view the predicates were frozen into an hourly snapshot, so expires_at and
+-- deleted_at did not take effect when they fell due — they took effect at the next refresh.
+-- Revocation was the sharper half: the snapshot holds a *copy* of deleted_at, so revoking a key
+-- left the copy reading NULL and the key kept being served, and kept signing, until the refresh.
+-- No predicate a reader could add would have seen it; the stale column was in the snapshot itself.
+--
+-- The leak-safety of this object has always been the predicate, not the materialization: requiring
+-- BOTH conditions is what stops deleted_at acting as a backdoor expiry for a key that was never
+-- revoked. That predicate is carried over verbatim. Only its evaluation moves, from refresh time to
+-- query time.
+--
+-- Reads stay cheap: keys is bounded by rotation, keys_usage_idx and the primary key cover both
+-- query shapes, and every consumer sits behind an in-process key cache.
+SELECT
+  cron.unschedule ('refresh-active-keys');
+
+-- Drops active_keys_usage_idx and active_keys_id_idx along with it; a plain view needs neither.
+DROP MATERIALIZED VIEW IF EXISTS active_keys;
+
+CREATE VIEW active_keys AS (
+  SELECT
+    *
+  FROM
+    keys
+  WHERE
+    expires_at > CURRENT_TIMESTAMP
+    AND (
+      deleted_at IS NULL
+      OR deleted_at > CURRENT_TIMESTAMP
+    )
+);


### PR DESCRIPTION
## Summary

`active_keys` was a materialized view, so its predicates were evaluated **once, at refresh time**.
`expires_at` and `deleted_at` therefore did not take effect when they fell due — they took effect at
the next hourly refresh.

Revocation was the sharper half, and worth stating precisely because it rules out the obvious fix: the
snapshot holds a **copy** of `deleted_at`. Revoking a key set `keys.deleted_at`, while
`active_keys.deleted_at` still read `NULL`. Re-applying the predicate at read time — the approach the
issue originally proposed — would have changed nothing, because the stale column was inside the
snapshot. Combined with the 30-minute in-process key cache, a revoked key kept **signing and
verifying** for up to ~90 minutes while the operator saw a successful write.

## Why a plain view rather than reading `keys` directly

The July 2025 migration did two independent things and joined them with "and": it materialized the
view *for read performance*, **and** replaced `COALESCE(deleted_at, expires_at) > now()` with explicit
conditions so `deleted_at` could no longer act as a backdoor expiry for a key that was never revoked.

The leak-safety is entirely the **predicate**. It is carried over verbatim here, so `active_keys`
remains the one object DAOs read, the model binding `bun:"table:keys,select:active_keys"` is untouched,
and neither DAO query changes. Only the evaluation moves, from refresh time to query time — which is
the fix.

What is genuinely given up is the 2025 performance intent. That looks like a good trade: `keys` is
bounded by rotation, `keys_usage_idx` and the primary key cover both query shapes, and every consumer
sits behind a 30-minute cache, so the database sees a handful of these per hour per process.

## What this also removes

- The `pg_cron` job — which a recent sweep found had been failing every hour between 2025-07-13 and
  2026-04-16 for want of the unique index, with the only trace in `cron.job_run_details`.
- `REFRESH MATERIALIZED VIEW CONCURRENTLY` from the rotation job, and the unique index that existed
  only to permit it.
- The `REFRESH` each of the three DAO tests issued between inserting fixtures and calling the DAO.

That last one is the point: those tests measured the view at the one instant it was guaranteed fresh,
which is never the production condition. `Error/Expired` and `Success/IgnoreExpiredAndDeleted` *looked*
like they proved exclusion and could not have failed for this defect. Removing the refresh is what
makes them test the predicate.

`TestPgJwkDeleteTakesEffectImmediately` covers the gap none of them had — nothing anywhere asserted
that a revoked key left the read path.

## Test plan

- [x] With the migration removed (schema reverted to the materialized view), the suite fails —
      `TestPgJwkDeleteTakesEffectImmediately`, plus `TestPgJwkSelect/Success`,
      `TestPgJwkSearch/Success/*` and the downstream `TestClaimsVerifier` / `TestClient`, which now
      depend on live evaluation rather than a hand-issued refresh
- [x] `a-novel test --type=go -y` passes with it in place
- [x] `golangci-lint` reports 0 issues; `prettier --check` passes (it reformatted the new SQL)
- [x] No migration prefix collision
- [ ] CI green

## Out of scope

**The in-process cache is untouched.** `jwk.Source` caches for 30 minutes on both the signer and every
consumer, so a revoked key stays usable in already-warm caches regardless of what the database says.
This closes the window at the database deterministically; closing it end-to-end needs a push or a
short-TTL path, which is the open question on the issue.

**The database image still ships `pg_cron`.** Nothing uses it after this change, but migration
`20250713173700` calls `cron.schedule(...)` and this service is deployed, so that migration is
immutable and a fresh database still needs the schema to replay history. Filed separately.

Closes #823