### PR TITLE
fix(ci): read the coverage artifact id from the renamed test job

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -440,7 +440,7 @@ jobs:
         with:
           codecov_token: ${{ secrets.CODECOV_TOKEN }}
           coverage_files: coverage.txt,coverage_pkg.txt,coverage/*
-          coverage_artifact_ids: ${{ needs.test.outputs.artifact-id }},${{ needs.test-pkg.outputs.artifact-id }},${{ needs.test-pkg-js.outputs.artifact-id }}
+          coverage_artifact_ids: ${{ needs.test-go.outputs.artifact-id }},${{ needs.test-pkg.outputs.artifact-id }},${{ needs.test-pkg-js.outputs.artifact-id }}
 
   publish-docs:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

`report-codecov` built `coverage_artifact_ids` from `needs.test`, a job that no longer exists — the Go unit-test job was renamed to `test-go` and only this expression kept the old name. GitHub resolves an unknown `needs.<job>` to an empty string rather than failing, so the upload ran green while silently dropping the Go coverage artifact.

`report-codecov` already listed `test-go` in its own `needs:`, so the dependency was right and only the reference was stale. `service-narrative-engine` carries the corrected form.

## Breaking changes

None.

## Test plan

- [x] Verified no job named `test` exists in this workflow
- [ ] CI green — the codecov upload should now carry the Go coverage artifact

Closes #837