### PR TITLE
refactor(pkg-js): validate REST responses against a Zod schema

### DIFF
--- a/pkg/js/rest/package.json
+++ b/pkg/js/rest/package.json
@@ -22,10 +22,12 @@
   "devDependencies": {
     "@a-novel-kit/nodelib-browser": "^1.3.18",
     "typescript": "^6.0.0",
-    "vite": "^8.0.0"
+    "vite": "^8.0.0",
+    "zod": "^4.1.12"
   },
   "peerDependencies": {
-    "@a-novel-kit/nodelib-browser": "^1.3.18"
+    "@a-novel-kit/nodelib-browser": "^1.3.18",
+    "zod": "^4.3.6"
   },
   "packageManager": "pnpm@11.15.1",
   "engines": {

--- a/pkg/js/rest/src/api.ts
+++ b/pkg/js/rest/src/api.ts
@@ -1,4 +1,12 @@
-import { handleHttpResponse } from "@a-novel-kit/nodelib-browser/http";
+import { decodeHttpResponse, handleHttpResponse } from "@a-novel-kit/nodelib-browser/http";
+
+import type { ZodType } from "zod";
+
+// Fallback decoder used when no schema is supplied: parses the JSON body as-is,
+// trusting it to match T.
+async function decodeRawHttpResponse<T>(response: Response): Promise<T> {
+  return await response.json();
+}
 
 /** Status of a single health-check dependency reported by the `/healthcheck` endpoint. */
 export type HealthDependency = {
@@ -30,13 +38,15 @@ export class JsonKeysApi {
   }
 
   /**
-   * Sends a request to the given path and deserializes the JSON response body as `T`.
-   * Throws if the server returns a non-2xx status or the body is not valid JSON.
+   * Sends a request to the given path and deserializes the JSON response body as `T`,
+   * validating it against the schema when one is given.
+   * Throws if the server returns a non-2xx status, the body is not valid JSON, or the
+   * body does not satisfy the schema.
    */
-  async fetch<T>(input: string, init?: RequestInit): Promise<T> {
+  async fetch<T>(input: string, validator?: ZodType<T>, init?: RequestInit): Promise<T> {
     return await fetch(`${this._baseUrl}${input}`, init)
       .then(handleHttpResponse)
-      .then((res) => res.json() as Promise<T>);
+      .then(validator ? decodeHttpResponse(validator) : decodeRawHttpResponse<T>);
   }
 
   /** Checks that the server is reachable. Throws on any non-2xx response. */
@@ -50,6 +60,6 @@ export class JsonKeysApi {
    * so inspect each entry's `status` field to detect one.
    */
   async health(): Promise<Record<string, HealthDependency>> {
-    return await this.fetch("/healthcheck", { method: "GET" });
+    return await this.fetch("/healthcheck", undefined, { method: "GET" });
   }
 }

--- a/pkg/js/rest/src/jwk.ts
+++ b/pkg/js/rest/src/jwk.ts
@@ -2,11 +2,42 @@ import type { JsonKeysApi } from "./api";
 
 import { HTTP_HEADERS } from "@a-novel-kit/nodelib-browser/http";
 
+import { z } from "zod";
+
+export const JwkKeyOpSchema = z.enum([
+  "sign",
+  "verify",
+  "encrypt",
+  "decrypt",
+  "wrapKey",
+  "unwrapKey",
+  "deriveKey",
+  "deriveBits",
+]);
+
 /**
  * Permitted cryptographic operations for a JSON Web Key, as defined by the `key_ops`
  * field in RFC 7517. The value constrains how the key may be used by a consumer.
  */
-export type JwkKeyOp = "sign" | "verify" | "encrypt" | "decrypt" | "wrapKey" | "unwrapKey" | "deriveKey" | "deriveBits";
+export type JwkKeyOp = z.infer<typeof JwkKeyOpSchema>;
+
+/**
+ * Parses a public JSON Web Key. The schema is loose because a key carries
+ * algorithm-specific parameters beyond the standard fields (`x` and `crv` for EdDSA,
+ * `n` and `e` for RSA), and those vary by key type.
+ */
+export const JwkSchema = z.looseObject({
+  /** Key type (e.g., `"OKP"` for EdDSA, `"EC"` for elliptic curve). */
+  kty: z.string(),
+  /** Intended use: `"sig"` for signature verification or `"enc"` for encryption. */
+  use: z.string(),
+  /** Permitted operations for this key. */
+  key_ops: z.array(JwkKeyOpSchema),
+  /** Signing algorithm (e.g., `"EdDSA"`). */
+  alg: z.string(),
+  /** Key ID. Matches the `kid` header field in JWTs signed with this key. */
+  kid: z.string(),
+});
 
 /**
  * A JSON Web Key (RFC 7517) as returned by the JSON-keys service.
@@ -14,23 +45,8 @@ export type JwkKeyOp = "sign" | "verify" | "encrypt" | "decrypt" | "wrapKey" | "
  * Only public keys are exposed over the REST API — private key material never leaves
  * the server. Use the `kid` field to match a key against the `kid` header in a JWT
  * when selecting the right key for verification.
- *
- * The index signature (`[key: string]: unknown`) covers algorithm-specific parameters
- * (e.g., `x` and `crv` for EdDSA keys) that vary by key type.
  */
-export type Jwk = {
-  /** Key type (e.g., `"OKP"` for EdDSA, `"EC"` for elliptic curve). */
-  kty: string;
-  /** Intended use: `"sig"` for signature verification or `"enc"` for encryption. */
-  use: string;
-  /** Permitted operations for this key. */
-  key_ops: JwkKeyOp[];
-  /** Signing algorithm (e.g., `"EdDSA"`). */
-  alg: string;
-  /** Key ID. Matches the `kid` header field in JWTs signed with this key. */
-  kid: string;
-  [key: string]: unknown;
-};
+export type Jwk = z.infer<typeof JwkSchema>;
 
 /**
  * Returns all active public keys for the given usage.
@@ -42,7 +58,10 @@ export async function jwkList(api: JsonKeysApi, usage?: string): Promise<Jwk[]> 
   const params = new URLSearchParams();
   if (usage) params.set("usage", usage);
   const query = params.toString();
-  return await api.fetch(`/jwks${query ? `?${query}` : ""}`, { method: "GET", headers: HTTP_HEADERS.JSON });
+  return await api.fetch(`/jwks${query ? `?${query}` : ""}`, z.array(JwkSchema), {
+    method: "GET",
+    headers: HTTP_HEADERS.JSON,
+  });
 }
 
 /**
@@ -57,5 +76,5 @@ export async function jwkList(api: JsonKeysApi, usage?: string): Promise<Jwk[]> 
 export async function jwkGet(api: JsonKeysApi, id: string): Promise<Jwk> {
   const params = new URLSearchParams();
   params.set("id", id);
-  return await api.fetch(`/jwk?${params.toString()}`, { method: "GET", headers: HTTP_HEADERS.JSON });
+  return await api.fetch(`/jwk?${params.toString()}`, JwkSchema, { method: "GET", headers: HTTP_HEADERS.JSON });
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -126,6 +126,9 @@ importers:
       vite:
         specifier: ^8.0.0
         version: 8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)
+      zod:
+        specifier: ^4.1.12
+        version: 4.4.3
 
   pkg/js/test/rest:
     devDependencies:


### PR DESCRIPTION
## Summary

This was the only client in the fleet whose `fetch` did not validate the response body. `service-template`, `service-authentication` and `service-narrative-engine` all take `fetch<T>(input, validator?: ZodType<T>, init?)` and derive their domain types with `z.infer`; here the shape was a hand-written `type` that nothing checked at runtime, so drift between the server and the declared type reached callers as a silently wrong object.

- `api.ts` takes the three-argument `fetch`, with the same `decodeRawHttpResponse` fallback the other clients use when no schema is given.
- `jwk.ts` defines `JwkKeyOpSchema` and `JwkSchema`, and `Jwk` / `JwkKeyOp` are now inferred from them, so the type cannot drift from what validates.
- `zod` joins peer and dev dependencies, matching the versions the other clients pin.

`JwkSchema` is a `looseObject` on purpose: the OpenAPI contract requires `kty`, `use`, `key_ops`, `alg` and `kid`, and a key carries algorithm-specific public-key material beyond them (`x` and `crv` for EdDSA, `n` and `e` for RSA). A strict object would reject every real key.

## Layers changed

- **pkg/js**: `api.ts` fetch signature, `jwk.ts` schemas and inferred types, client `package.json` deps.

## Breaking changes

None for callers. `Jwk` and `JwkKeyOp` keep their exported names and resolve to the same shape; `api.fetch` gains a middle parameter, but it is only called from inside this package. `zod` is a peer dependency, so a consumer that does not already have it will need to install it.

## Test plan

- [x] `pnpm lint:ci` green — build, both typechecks, eslint, prettier, redocly
- [x] `a-novel test --type=pnpm -y` green against a live service, so the schema is verified against real responses rather than against the old type
- [ ] CI green

Closes #838