### PR TITLE
test(ci): run the key-rotation job, instead of only building it

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -79,9 +79,21 @@ jobs:
     env:
       POSTGRES_DSN_TEST: postgres://postgres:postgres@localhost:5432/postgres?sslmode=disable
       POSTGRES_DSN: postgres://postgres:postgres@localhost:5432/postgres?sslmode=disable
+      APP_MASTER_KEY: "fec0681a2f57242211c559ca347721766f8a3acd8ed2e63b36b3768051c702ca"
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/run-migrations
+      # The rotation job was built by CI and never run, so nothing exercised its
+      # wiring: the config it loads, the database context it seeds, the services
+      # it assembles. Unit tests cover the logic; only the binary covers the binary.
+      #
+      # Twice on purpose. The job ensures a key per usage, so it is safe to re-run,
+      # and the second run is what catches it tripping over what the first wrote.
+      - name: Run the key-rotation job
+        shell: bash
+        run: |
+          go run ./cmd/rotate-keys
+          go run ./cmd/rotate-keys
       - uses: a-novel-kit/workflows/go-actions/test-go@v1.20.2
         id: test
         with:


### PR DESCRIPTION
CI built `rotate-keys` into an image and never ran it. The rotation logic is unit-tested since #833; the binary is not — the config it loads, the database context it seeds, the services it assembles. A wiring mistake ships green.

It now runs in the lane that already has a database and applied migrations.

Refs a-novel/service-template#404

## Twice

The job ensures a key per usage, so it is meant to be safe to re-run. The second invocation is what catches it tripping over the keys the first wrote — the failure mode a scheduled job actually has.

Verified locally: migrations, then two consecutive runs, both reporting two usages processed.

## Scope

A smoke test. It asserts the job boots, connects and completes. What lands in the database is the unit tests' job.

## Correction to the issue behind it

a-novel/service-template#404 says job binaries are never executed by any lane. I filed that, from grepping filter patterns. `cmd/migrations` is executed by `run-migrations` in three lanes, and the servers run as containers in `test-pkg`. The gap is non-migration jobs: `rotate-keys` here and `cmd/init` in `service-authentication`. `service-template` has neither.