### PR TITLE
docs: trim and refocus code comments

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -335,9 +335,8 @@ jobs:
       id-token: write
     outputs:
       digest: ${{ steps.build.outputs.digest }}
-    # This image is booted and exercised by test-pkg (a full
-    # integration run), so this job only builds + pushes it. skip_healthcheck
-    # drops the redundant smoke run and the container constellation it needed.
+    # test-pkg boots and exercises this image in a full integration run, so this job only
+    # builds and pushes it; skip_healthcheck drops the redundant smoke run.
     steps:
       - uses: a-novel-kit/workflows/build-actions/docker@v1.20.1
         id: build
@@ -394,9 +393,8 @@ jobs:
       id-token: write
     outputs:
       digest: ${{ steps.build.outputs.digest }}
-    # This image is booted and exercised by test-pkg-js (a full
-    # integration run), so this job only builds + pushes it. skip_healthcheck
-    # drops the redundant smoke run and the container constellation it needed.
+    # test-pkg-js boots and exercises this image in a full integration run, so this job only
+    # builds and pushes it; skip_healthcheck drops the redundant smoke run.
     steps:
       - uses: a-novel-kit/workflows/build-actions/docker@v1.20.1
         id: build
@@ -446,8 +444,8 @@ jobs:
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/master' && success()
     needs: [build-js]
-    # GitHub Pages allows a single deployment in flight per site; without this
-    # group, concurrent master runs fail with "in progress deployment" errors.
+    # GitHub Pages allows one deployment in flight per site; the group serializes concurrent
+    # master runs, which would otherwise fail with "in progress deployment".
     concurrency:
       group: github-pages
       cancel-in-progress: false

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -444,8 +444,8 @@ jobs:
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/master' && success()
     needs: [build-js]
-    # GitHub Pages allows one deployment in flight per site; the group serializes concurrent
-    # master runs, which would otherwise fail with "in progress deployment".
+    # GitHub Pages allows one deployment in flight per site. The group serializes concurrent
+    # master runs.
     concurrency:
       group: github-pages
       cancel-in-progress: false

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,14 +1,13 @@
 name: release
 
-# Releases are cut from the GitHub UI (Actions ▸ release ▸ pick a type ▸ Run),
-# not from a tag push. workflow_call exposes the same inputs so an agent can
-# drive an identical release later. The protected `release` environment is the
-# "who can publish" gate (configure its required reviewers).
+# Releases are cut from the GitHub UI (Actions ▸ release ▸ pick a type ▸ Run). workflow_call
+# exposes the same inputs so an agent can drive an identical release later. The protected
+# `release` environment is the "who can publish" gate (configure its required reviewers).
 #
-# The build jobs run on the default branch (the dispatch ref), not a tag, so
-# each tags its image from the explicit release version (build-actions `version:`
-# input) and pulls the database service image at the new tag; build-js publishes
-# from the release tag (ref) so the package carries the bumped version.
+# The build jobs run on the dispatch ref, the default branch, so each tags its image from the
+# explicit release version (build-actions `version:` input) and pulls the database service
+# image at the new tag; build-js publishes from the release tag (ref) so the package carries
+# the bumped version.
 on:
   workflow_dispatch:
     inputs:
@@ -316,8 +315,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           run_args: -e POSTGRES_DSN="${POSTGRES_DSN}" -e APP_MASTER_KEY="${APP_MASTER_KEY}"
 
-  # Publish the JS client from the bumped tag (ref) so it carries the new
-  # version rather than the pre-bump default branch.
+  # Publish the JS client from the bumped tag (ref) so the package carries the new version.
   build-js:
     needs: [release]
     if: ${{ !inputs.dry_run }}

--- a/builds/database.Dockerfile
+++ b/builds/database.Dockerfile
@@ -1,5 +1,5 @@
 # PostgreSQL image with this service's extensions pre-installed at build time.
-# Database migrations are not included; run the migrations image separately after deployment.
+# Run the migrations image separately after deployment to create the schema.
 FROM docker.io/library/postgres:18.4
 
 ARG DEBIAN_FRONTEND=noninteractive
@@ -7,9 +7,8 @@ ARG DEBIAN_FRONTEND=noninteractive
 # SQL script run on first container start to install PostgreSQL extensions.
 COPY ./builds/database.sql /docker-entrypoint-initdb.d/init.sql
 
-# Default PostgreSQL port.
 EXPOSE 5432
 
-# Postgres does not provide a healthcheck by default.
+# The postgres image ships no healthcheck of its own.
 HEALTHCHECK --interval=1s --timeout=5s --retries=10 --start-period=1s \
   CMD pg_isready || exit 1

--- a/builds/grpc.Dockerfile
+++ b/builds/grpc.Dockerfile
@@ -1,20 +1,17 @@
 # Runs the JSON-keys gRPC server. Requires a database with migrations already applied.
 FROM docker.io/library/golang:1.26.5-alpine AS builder
 
-# CGO_ENABLED=0 produces a fully static binary with no C library dependency,
-# which is required for safe execution on Alpine (musl libc).
+# CGO_ENABLED=0 produces a fully static binary, required to run safely on Alpine's musl libc.
 ENV CGO_ENABLED=0
 
 WORKDIR /app
 
-# Download dependencies before copying source files so the module cache layer is
-# reused on rebuilds where only source files change.
+# Download dependencies before the source copy, so the module layer survives source-only rebuilds.
 COPY go.mod go.sum ./
 RUN --mount=type=cache,target=/go/pkg/mod \
     go mod download
 
-# Install grpcurl for the healthcheck. Placed before source COPY so the cached
-# layer (download + compile) survives source-only rebuilds.
+# grpcurl backs the healthcheck; installing it before the source copy keeps its layer cached too.
 RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
     GOBIN=/usr/local/bin go install github.com/fullstorydev/grpcurl/cmd/grpcurl@v1.9.3
@@ -43,7 +40,6 @@ HEALTHCHECK --interval=1s --timeout=5s --retries=10 --start-period=1s \
 
 ENV GRPC_PORT=8080
 
-# gRPC port.
 EXPOSE 8080
 # TLS port.
 EXPOSE 443

--- a/builds/rest.Dockerfile
+++ b/builds/rest.Dockerfile
@@ -31,7 +31,6 @@ HEALTHCHECK --interval=1s --timeout=5s --retries=10 --start-period=1s \
 
 ENV REST_PORT=8080
 
-# REST API port.
 EXPOSE 8080
 
 CMD ["/rest"]

--- a/builds/rotate-keys.Dockerfile
+++ b/builds/rotate-keys.Dockerfile
@@ -1,6 +1,6 @@
 # Runs the key rotation job: generates new JSON Web Keys for each usage where the rotation
-# interval has elapsed. Requires a database with migrations already applied; does not
-# require a running server.
+# interval has elapsed. Requires a database with migrations already applied, and runs
+# independently of any server.
 FROM docker.io/library/golang:1.26.5-alpine AS builder
 
 ENV CGO_ENABLED=0

--- a/builds/standalone.grpc.Dockerfile
+++ b/builds/standalone.grpc.Dockerfile
@@ -1,6 +1,6 @@
 # Standalone gRPC server image for local development. Applies migrations and rotates keys
-# automatically before starting the server, so the database does not need to be pre-initialized.
-# For production deployments, use the base gRPC image (grpc.Dockerfile) instead.
+# automatically before starting the server, so the database needs no pre-initialization.
+# Production deployments use the base gRPC image (grpc.Dockerfile).
 FROM docker.io/library/golang:1.26.5-alpine AS builder
 
 ENV CGO_ENABLED=0
@@ -43,10 +43,8 @@ HEALTHCHECK --interval=1s --timeout=5s --retries=10 --start-period=1s \
 
 ENV GRPC_PORT=8080
 
-# gRPC port.
 EXPOSE 8080
 # TLS port.
 EXPOSE 443
 
-# Apply migrations and rotate keys, then start the server.
 CMD ["sh", "-c", "/migrations && /rotate-keys && /grpc"]

--- a/builds/standalone.rest.Dockerfile
+++ b/builds/standalone.rest.Dockerfile
@@ -1,6 +1,6 @@
 # Standalone REST server image for local development. Applies migrations and rotates keys
-# automatically before starting the server, so the database does not need to be pre-initialized.
-# For production deployments, use the base REST image (rest.Dockerfile) instead.
+# automatically before starting the server, so the database needs no pre-initialization.
+# Production deployments use the base REST image (rest.Dockerfile).
 FROM docker.io/library/golang:1.26.5-alpine AS builder
 
 ENV CGO_ENABLED=0
@@ -39,8 +39,6 @@ HEALTHCHECK --interval=1s --timeout=5s --retries=10 --start-period=1s \
 
 ENV REST_PORT=8080
 
-# REST port.
 EXPOSE 8080
 
-# Apply migrations and rotate keys, then start the server.
 CMD ["sh", "-c", "/migrations && /rotate-keys && /rest"]

--- a/cmd/grpc/main.go
+++ b/cmd/grpc/main.go
@@ -1,9 +1,6 @@
-// Command grpc runs the private gRPC server for the JSON-keys service.
-//
-// This server is the authenticated service-to-service API. It exposes token signing,
-// key retrieval, and health check endpoints. Because signing requires access to private
-// key material, the APP_MASTER_KEY environment variable must be set before starting the
-// server.
+// Command grpc runs the private gRPC server for the JSON-keys service: the authenticated
+// service-to-service API covering token signing and key retrieval. Signing needs the private
+// key material, so APP_MASTER_KEY must be set before the server starts.
 //
 // For the public read-only REST API, see cmd/rest.
 package main
@@ -67,8 +64,8 @@ func main() {
 	serviceJwkSearch := core.NewJwkSearch(daoJwkSearch, serviceJwkExtract)
 	serviceJwkSelect := core.NewJwkSelect(daoJwkSelect, serviceJwkExtract)
 
-	// Build the signing chain: a cached private-key source feeds per-usage producer plugins,
-	// which ClaimsSign uses to sign tokens without hitting the database on every request.
+	// The signing chain: a cached private-key source feeds the per-usage producer plugins, so
+	// ClaimsSign signs tokens without hitting the database on every request.
 	serviceExportLocal := core.NewJwkExportLocal(serviceJwkSearch)
 	serviceJwkSource := lo.Must(core.NewJwkPrivateSource(serviceExportLocal, config.JwkPresetDefault))
 	serviceJwkProducer := lo.Must(core.NewJwkProducers(serviceJwkSource, config.JwkPresetDefault))

--- a/cmd/migrations/main.go
+++ b/cmd/migrations/main.go
@@ -23,9 +23,8 @@ func main() {
 
 	start := time.Now()
 
-	// Inventory the .up.sql files up front for the start-of-run log. The
-	// bun migrator doesn't expose a count, so the embedded FS is the closest
-	// stable source.
+	// Inventory the .up.sql files for the start-of-run log; the bun migrator exposes no count,
+	// so the embedded FS is the closest stable source.
 	discovered := listUpMigrations(migrations.Migrations)
 	log.Printf("discovered %d migration(s) in models/migrations", len(discovered))
 
@@ -44,17 +43,16 @@ func main() {
 		len(discovered), time.Since(start).Round(time.Millisecond))
 }
 
-// listUpMigrations returns the bare name of every *.up.sql in the migrations
-// FS, in lexical order (the timestamp prefix makes that chronological). It
-// feeds the start-of-run inventory log only; bun's migrator decides which
-// migrations actually run.
+// listUpMigrations returns the bare name of every *.up.sql in the migrations FS, in lexical
+// order — the timestamp prefix makes that chronological. It feeds the inventory log; bun's
+// migrator decides which migrations actually run.
 func listUpMigrations(f fs.FS) []string {
 	var out []string
 
 	_ = fs.WalkDir(f, ".", func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
-			// Aborts the walk on error; the caller discards it, since the
-			// inventory is best-effort logging rather than a gate.
+			// Abort the walk; the caller discards the error, as the inventory
+			// is best-effort logging.
 			return err
 		}
 

--- a/cmd/rest/main.go
+++ b/cmd/rest/main.go
@@ -1,9 +1,6 @@
-// Command rest runs the public REST server for the JSON-keys service.
-//
-// This server exposes read-only JSON Web Key endpoints so that any client can fetch
-// public keys for local token verification. It does not expose
-// signing or any private key material. No authentication is required to access
-// these endpoints.
+// Command rest runs the public REST server for the JSON-keys service. It serves read-only
+// JSON Web Key endpoints, unauthenticated, so any client can fetch public keys for local
+// token verification. Signing and private key material stay off this surface.
 //
 // For the private authenticated gRPC API (including token signing), see cmd/grpc.
 package main

--- a/cmd/rotate-keys/main.go
+++ b/cmd/rotate-keys/main.go
@@ -1,6 +1,6 @@
-// Command rotate-keys rotates active JSON Web Keys. For each configured usage, it generates
-// a new key if the rotation interval has elapsed. Consumers see it on their next fetch:
-// active_keys is a plain view, so there is no snapshot to refresh.
+// Command rotate-keys rotates active JSON Web Keys: for each configured usage, it generates a
+// new key once the rotation interval has elapsed. Consumers pick the key up on their next
+// fetch, since active_keys is a plain view with no snapshot to refresh.
 //
 // Designed to run as a periodic job (e.g., a Kubernetes CronJob).
 package main
@@ -67,9 +67,6 @@ func main() {
 		err = otel.ReportError(span, fmt.Errorf("rotate keys: %w", err))
 		log.Fatalln(err.Error()) //nolint:gocritic
 	}
-
-	// active_keys is a plain view, so a newly inserted key is visible to the next reader
-	// with no refresh step to run — and none to forget.
 
 	otel.ReportSuccessNoContent(span)
 	log.Printf("done — %d usage(s) processed, completed in %s",

--- a/internal/config/configtest/postgres.go
+++ b/internal/config/configtest/postgres.go
@@ -1,13 +1,10 @@
-// Package configtest holds shared test fixtures for the config package. Production code must
-// not import it; only test files (in this or any other package's `_test.go` files) may.
+// Package configtest holds shared test fixtures for the config package. Only `_test.go` files
+// may import it.
 //
-// Isolation is enforced by convention, not by the language. Go links any package reachable
-// from a production import into the binary, regardless of where it lives — keeping configtest
-// out of every production import path is what guarantees these fixtures ship only with the
-// test binary. The split exists because the alternative — putting the fixtures next to the
-// production config files in a `*.test.go` file — does ship them: Go's build-time exclusion
-// rule only matches `_test.go` (with an underscore), not `.test.go` (with a dot). A dedicated
-// subpackage makes the boundary explicit and easy to lint or grep against.
+// Isolation is a convention the language does not enforce: Go links any package reachable from
+// a production import into the binary, so keeping configtest out of every production import
+// path is what confines these fixtures to the test binary. A dedicated subpackage makes that
+// boundary easy to lint or grep against.
 package configtest
 
 import (

--- a/internal/core/claimsVerify.go
+++ b/internal/core/claimsVerify.go
@@ -53,7 +53,7 @@ func (service *ClaimsVerify[Out]) Exec(ctx context.Context, request *ClaimsVerif
 
 	var claims Out
 
-	// Use the key configuration to further validate the token claims.
+	// Validate the claims against the usage's configured target, and its expiry unless waived.
 	checks := []jwp.ClaimsCheck{
 		jwp.NewClaimsCheckTarget(jwt.TargetConfig{
 			Issuer:   keyConfig.Token.Issuer,

--- a/internal/core/jwkExportLocal.go
+++ b/internal/core/jwkExportLocal.go
@@ -14,8 +14,7 @@ type JwkExportLocalSource interface {
 // A JwkExportLocal wraps the local JwkSearch service as a jwk.Source, so private keys can
 // be cached in memory and served without hitting the database on every request.
 //
-// This exporter is for internal (server-side) use only. The public client package uses its
-// own gRPC-backed exporter instead.
+// Server-side only; the public client package has its own gRPC-backed exporter.
 type JwkExportLocal struct {
 	service JwkExportLocalSource
 }

--- a/internal/core/jwkGen.go
+++ b/internal/core/jwkGen.go
@@ -46,11 +46,9 @@ type JwkGenRequest struct {
 
 // A JwkGen generates new keys for a configured usage.
 //
-// It does not force generation. When called, it inspects the current state of the
-// database to decide whether the usage is due for a new key.
-//
-// If the latest key for the usage is still within its rotation window, that key is
-// returned and generation is skipped; the skip is recorded on the trace span.
+// Generation is conditional: it reads the usage's latest key and generates only once the
+// rotation window has elapsed. Within the window it returns that key and records the skip
+// on the trace span.
 type JwkGen struct {
 	daoSearch      JwkGenDaoSearch
 	daoInsert      JwkGenDaoInsert
@@ -79,8 +77,7 @@ func (service *JwkGen) Exec(ctx context.Context, request *JwkGenRequest) (*Jwk, 
 
 	span.SetAttributes(attribute.String("key.usage", request.Usage))
 
-	// Check the last time a key was inserted for the target usage, and compare to config. If the last key is too
-	// recent, return without generating a new key.
+	// The newest key for the usage decides whether the rotation window has elapsed.
 	keys, err := service.daoSearch.Exec(ctx, &dao.JwkSearchRequest{Usage: request.Usage})
 	if err != nil {
 		return nil, otel.ReportError(span, fmt.Errorf("list keys: %w", err))
@@ -122,7 +119,7 @@ func (service *JwkGen) Exec(ctx context.Context, request *JwkGenRequest) (*Jwk, 
 			attribute.String("key.alg", string(keyConfig.Alg)),
 		))
 
-		// Encrypt the private key using the master key, so it is protected against database dumping.
+		// Encrypt the private key with the master key, so a database dump does not expose it.
 		privateKeyEncrypted, err := lib.EncryptMasterKey(ctx, privateKey)
 		if err != nil {
 			return nil, otel.ReportError(span, fmt.Errorf("encrypt private key: %w", err))

--- a/internal/core/jwkPresets.go
+++ b/internal/core/jwkPresets.go
@@ -17,9 +17,8 @@ var (
 	// ErrJwkPresetUnknown is returned when a requested algorithm has no corresponding preset entry.
 	ErrJwkPresetUnknown = errors.New("unknown jwk preset")
 	// ErrJwkPresetUnknownAlgorithm is returned when a key configuration references an algorithm
-	// for which no key-source builder is registered. Only asymmetric algorithms (EdDSA, ECDSA,
-	// RSA, RSA-PSS) are supported — symmetric algorithms like HMAC are deliberately excluded
-	// because their secrets cannot be safely separated into a public-key REST surface.
+	// with no registered key-source builder. Only asymmetric algorithms are supported: a
+	// symmetric secret has no public half to publish on the REST surface.
 	ErrJwkPresetUnknownAlgorithm = errors.New("unknown jwk algorithm")
 )
 
@@ -132,7 +131,7 @@ func JwkGeneratorRsa(alg jwa.Alg) func() (any, any, string, string, error) {
 
 // JwkPrivateSources holds typed, cached private-key sources for each supported algorithm family,
 // grouped by usage name, and is used to wire signing plugins for JWT production. Only asymmetric
-// algorithms are supported; symmetric (HMAC) algorithms are not.
+// algorithms are supported.
 type JwkPrivateSources struct {
 	EdDSA map[string]*jwk.Source
 	ES    map[string]*jwk.Source
@@ -168,8 +167,8 @@ func NewJwkPrivateSource(
 			Fetch:         fetch,
 		})
 
-		// One algorithm-agnostic source per usage; the bucket only records which signer plugin to
-		// wire later (jwt v2 decodes the key type at the plugin, not the source).
+		// One algorithm-agnostic source per usage; the bucket records which signer plugin to wire
+		// later, since jwt v2 decodes the key type at the plugin.
 		switch keyConfig.Alg {
 		case jwa.EdDSA:
 			output.EdDSA[usage] = keySource
@@ -187,7 +186,7 @@ func NewJwkPrivateSource(
 
 // JwkPublicSources holds typed, cached public-key sources for each supported algorithm family,
 // grouped by usage name, and is used to wire verification plugins for JWT consumption. Only
-// asymmetric algorithms are supported; symmetric (HMAC) algorithms are not.
+// asymmetric algorithms are supported.
 type JwkPublicSources struct {
 	EdDSA map[string]*jwk.Source
 	ES    map[string]*jwk.Source
@@ -223,8 +222,8 @@ func NewJwkPublicSource(
 			Fetch:         fetch,
 		})
 
-		// One algorithm-agnostic source per usage; the bucket only records which verifier plugin to
-		// wire later (jwt v2 decodes the key type at the plugin, not the source).
+		// One algorithm-agnostic source per usage; the bucket records which verifier plugin to wire
+		// later, since jwt v2 decodes the key type at the plugin.
 		switch keyConfig.Alg {
 		case jwa.EdDSA:
 			output.EdDSA[usage] = keySource

--- a/internal/core/jwkRotateAll.go
+++ b/internal/core/jwkRotateAll.go
@@ -17,27 +17,21 @@ type JwkRotateAllServiceGen interface {
 	Exec(ctx context.Context, request *JwkGenRequest) (*Jwk, error)
 }
 
-// JwkRotateAllRequest holds the parameters for a [JwkRotateAll.Exec] call. It is
-// empty because the set of usages to rotate is configuration, not a caller's
-// choice — but it exists so the operation can gain one without breaking callers.
+// JwkRotateAllRequest holds the parameters for a [JwkRotateAll.Exec] call. The set of usages
+// to rotate comes from configuration, so it is empty; it exists so the operation can gain a
+// parameter without breaking callers.
 type JwkRotateAllRequest struct{}
 
 // JwkRotateAllResponse reports the outcome of a [JwkRotateAll.Exec] call.
 type JwkRotateAllResponse struct {
-	// Processed counts the usages that were ensured. It is only meaningful when the
-	// call returned no error: a partial count describes work that has been rolled
-	// back, and reporting it would say keys were rotated when none were.
+	// Processed counts the usages that were ensured. It is meaningful only when the call
+	// returned no error; on failure the transaction rolls back and nothing was rotated.
 	Processed int
 }
 
-// A JwkRotateAll ensures every configured usage has a current key, as a single
-// unit of work: a failure partway through leaves none of them rotated.
-//
-// That atomicity is the reason it takes a transactor rather than reaching for one.
-// The rotation used to open a transaction and then hand each generation the
-// surrounding context, so every key committed on its own and a failure on the
-// third usage left the first two rotated — while the job reported failure as
-// though nothing had been written.
+// A JwkRotateAll ensures every configured usage has a current key, as a single unit of work:
+// the injected transactor wraps the whole rotation, so a failure partway through leaves none
+// of the usages rotated.
 type JwkRotateAll struct {
 	serviceGen JwkRotateAllServiceGen
 	transactor transaction.Transactor

--- a/internal/core/jwkSearch.go
+++ b/internal/core/jwkSearch.go
@@ -67,7 +67,6 @@ func (service *JwkSearch) Exec(ctx context.Context, request *JwkSearchRequest) (
 
 	span.SetAttributes(attribute.Int("entities.count", len(entities)))
 
-	// Don't use lo so we can handle errors properly.
 	deserialized := make([]*Jwk, len(entities))
 
 	for i, entity := range entities {

--- a/internal/dao/pg.jwk.go
+++ b/internal/dao/pg.jwk.go
@@ -11,7 +11,7 @@ import (
 //
 // Private keys must be encrypted with the master key before storage.
 //
-// A Jwk is never hard-deleted. Instead, DAOs query through an "active_keys" view that
+// Rows are soft-deleted and stay in the table; DAOs read through an "active_keys" view that
 // excludes expired and soft-deleted rows. Keys are grouped by [Jwk.Usage]; for each usage there
 // is a single main key (the latest) and zero or more legacy keys (older active versions).
 type Jwk struct {
@@ -29,19 +29,13 @@ type Jwk struct {
 
 	// Usage identifies the signing purpose this key serves.
 	//
-	// A particular Usage value should be registered by a single service, which becomes
-	// the "producer" for this usage. Only the producer should be allowed to perform
-	// operations requiring the private key (e.g., generating a token).
+	// A usage is registered by a single service, its "producer", and only the producer may use
+	// the private key to sign. Any client may fetch the public key for a usage and become a
+	// "recipient" that verifies what the producer signed.
 	//
-	// Any client may consume the public key for a given usage and become a "recipient".
-	// Recipients can use the public key of a producer to verify the data they receive.
-	//
-	// All keys registered under the same usage are considered different versions of the
-	// same key. When a new key is registered for a usage, it becomes the "main" key, and
-	// the other keys are converted to "legacy" keys.
-	//
-	// A producer signs only with the main key. Recipients can verify tokens signed
-	// by any active key for the usage.
+	// All keys under one usage are versions of the same key: the newest is the "main" key, the
+	// rest are "legacy". A producer signs only with the main key; recipients accept any active
+	// key for the usage.
 	Usage string `bun:"usage"`
 
 	// CreatedAt is when the key was generated and persisted; it determines the

--- a/internal/dao/pg.jwkDelete.go
+++ b/internal/dao/pg.jwkDelete.go
@@ -31,12 +31,12 @@ type JwkDeleteRequest struct {
 	Comment string
 }
 
-// A PgJwkDelete prematurely soft-deletes a JSON Web Key: the key is removed from the active
-// view and disappears from API results, but is retained in the database for auditing.
+// A PgJwkDelete prematurely soft-deletes a JSON Web Key: the key leaves the active view and
+// disappears from API results, while the row is retained for auditing.
 //
-// Do not call this when a key expires naturally — expired keys are removed from the active view
-// automatically. Only active keys can be targeted; if the key is already deleted or expired,
-// [ErrJwkDeleteNotFound] is returned.
+// Only active keys can be targeted; an already deleted or expired key yields
+// [ErrJwkDeleteNotFound]. Natural expiry needs no call here — the active view drops expired
+// keys on its own.
 type PgJwkDelete struct{}
 
 // NewPgJwkDelete returns a new PgJwkDelete dao.

--- a/internal/dao/pg.jwkSearch.go
+++ b/internal/dao/pg.jwkSearch.go
@@ -14,11 +14,8 @@ import (
 //go:embed pg.jwkSearch.sql
 var jwkSearchQuery string
 
-// KeysMaxBatchSize is the maximum number of keys returned by a single search operation.
-//
-// Regular key rotation and TTL-based expiration normally keep the number of active keys per usage
-// low, so the search has no pagination. This limit exists as a safeguard in case of misconfiguration
-// or unexpected key accumulation.
+// KeysMaxBatchSize is the maximum number of keys returned by a single search operation. It is a
+// safeguard against misconfiguration or unexpected key accumulation.
 const KeysMaxBatchSize = 100
 
 // ErrJwkSearchTooManyResults is logged (not returned) when a search hits the [KeysMaxBatchSize]
@@ -66,8 +63,7 @@ func (dao *PgJwkSearch) Exec(ctx context.Context, request *JwkSearchRequest) ([]
 		attribute.Int("keys.max_batch_size", KeysMaxBatchSize),
 	)
 
-	// Log an error when too many keys are found, as this indicates a potential misconfiguration.
-	// The results found so far are still returned to the caller.
+	// Hitting the cap signals a misconfiguration; log it and return what was found.
 	if len(entities) >= KeysMaxBatchSize {
 		err = fmt.Errorf("%w: %d keys found for usage %s", ErrJwkSearchTooManyResults, len(entities), request.Usage)
 

--- a/internal/handlers/doc.go
+++ b/internal/handlers/doc.go
@@ -1,14 +1,12 @@
-// Package handlers is the transport layer of the JSON-keys application, sitting above
-// the service layer.
+// Package handlers is the transport layer of the JSON-keys application, sitting above the
+// core layer. Handlers translate incoming requests into core calls and map the results back
+// to protocol-level responses; business logic lives in core.
 //
-// There are two transport implementations, each serving a distinct audience:
+// Two transport implementations serve distinct audiences:
 //
 //   - gRPC handlers: the private API for authenticated service-to-service calls, covering
 //     token signing, key retrieval, and dependency health checks. Wired by cmd/grpc.
 //
-//   - REST handlers: the public, read-only API for token verification, exposing the
-//     JSON Web Keys without requiring authentication. Wired by cmd/rest.
-//
-// All handlers translate incoming requests into service-layer calls and map the results
-// back to protocol-level responses. They do not contain business logic.
+//   - REST handlers: the public, unauthenticated read-only API exposing the JSON Web Keys
+//     used for token verification. Wired by cmd/rest.
 package handlers

--- a/internal/handlers/grpc.status.go
+++ b/internal/handlers/grpc.status.go
@@ -15,10 +15,8 @@ import (
 // NewGrpcHealthStatus converts an error into a DependencyHealth proto message,
 // mapping nil to DEPENDENCY_STATUS_UP and any non-nil error to DEPENDENCY_STATUS_DOWN.
 //
-// The error itself is intentionally discarded from the returned message; raw dependency
-// errors routinely embed internal hostnames, ports, or schema names that would leak
-// infrastructure topology. Operators get the underlying error from the trace span the
-// failing health probe records on its way out.
+// The error is dropped from the message: raw dependency errors embed internal hostnames,
+// ports and schema names. Operators read it from the trace span the failing probe records.
 func NewGrpcHealthStatus(err error) *protogen.DependencyHealth {
 	return &protogen.DependencyHealth{
 		Status: lo.Ternary(

--- a/internal/handlers/protogen/jwk_list_grpc.pb.go
+++ b/internal/handlers/protogen/jwk_list_grpc.pb.go
@@ -26,8 +26,7 @@ const (
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
 //
-// JwkListService lists the active keys for a given usage, newest first: the first key is
-// the current signing key, the rest are older keys still trusted for verification.
+// JwkListService lists the active public keys for a given usage.
 type JwkListServiceClient interface {
 	// Returns the active public keys for the given usage, newest first. The first key is the
 	// current signing key; the rest are older keys still trusted for verifying tokens issued
@@ -57,8 +56,7 @@ func (c *jwkListServiceClient) JwkList(ctx context.Context, in *JwkListRequest, 
 // All implementations must embed UnimplementedJwkListServiceServer
 // for forward compatibility.
 //
-// JwkListService lists the active keys for a given usage, newest first: the first key is
-// the current signing key, the rest are older keys still trusted for verification.
+// JwkListService lists the active public keys for a given usage.
 type JwkListServiceServer interface {
 	// Returns the active public keys for the given usage, newest first. The first key is the
 	// current signing key; the rest are older keys still trusted for verifying tokens issued

--- a/internal/handlers/protogen/status.pb.go
+++ b/internal/handlers/protogen/status.pb.go
@@ -79,10 +79,9 @@ func (DependencyStatus) EnumDescriptor() ([]byte, []int) {
 
 // DependencyHealth reports the health of a single external dependency.
 //
-// The shape is deliberately minimal. This gRPC surface is internal today, but errors from a
-// dependency health check routinely embed internal hostnames, ports, or schema names, and
-// carrying them in the response would leak infrastructure topology if it ever became
-// externally reachable. The underlying error is recorded on the trace span for operators.
+// The message carries the status alone. Health-check errors embed internal hostnames, ports and
+// schema names, and this gRPC surface may not stay internal forever. The underlying error is
+// recorded on the trace span for operators.
 type DependencyHealth struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// The dependency's current operational status.

--- a/internal/handlers/rest.health.go
+++ b/internal/handlers/rest.health.go
@@ -20,18 +20,17 @@ const (
 )
 
 // RestHealthStatus is the JSON representation of a single dependency's health.
-// The shape is deliberately minimal: /healthcheck is an unauthenticated public
-// endpoint, so it must not expose raw error messages — those routinely include
-// internal hostnames, ports, or schema names that leak infrastructure topology.
-// The underlying error is recorded on the trace span for operators instead.
+// /healthcheck is public and unauthenticated, so the body carries the status alone:
+// raw error messages embed internal hostnames, ports and schema names. The underlying
+// error is recorded on the trace span for operators.
 type RestHealthStatus struct {
 	// Status is either [RestHealthStatusUp] or [RestHealthStatusDown].
 	Status string `json:"status"`
 }
 
 // NewRestHealthStatus converts an error into a RestHealthStatus, mapping nil to
-// [RestHealthStatusUp] and any non-nil error to [RestHealthStatusDown]. The error
-// itself is intentionally discarded from the public response; see [RestHealthStatus].
+// [RestHealthStatusUp] and any non-nil error to [RestHealthStatusDown]. The error is
+// dropped from the public response; see [RestHealthStatus].
 func NewRestHealthStatus(err error) *RestHealthStatus {
 	return &RestHealthStatus{
 		Status: lo.Ternary(err == nil, RestHealthStatusUp, RestHealthStatusDown),

--- a/internal/lib/masterKeyContext.go
+++ b/internal/lib/masterKeyContext.go
@@ -25,8 +25,7 @@ const MasterKeyLength = 32
 // in the database. It must be kept secret and generated with a cryptographically secure
 // random source.
 //
-// Rotating this secret permanently invalidates all private keys encrypted with the old value,
-// so update it with care.
+// Rotating this secret permanently invalidates every private key encrypted with the old value.
 func NewMasterKeyContext(ctx context.Context, masterKeyRaw string) (context.Context, error) {
 	ctx, span := otel.Tracer().Start(ctx, "lib.NewMasterKeyContext")
 	defer span.End()
@@ -43,7 +42,7 @@ func NewMasterKeyContext(ctx context.Context, masterKeyRaw string) (context.Cont
 		))
 	}
 
-	// secretbox needs the key as a fixed-size array, not a slice.
+	// secretbox needs the key as a fixed-size array.
 	var masterKey [MasterKeyLength]byte
 	copy(masterKey[:], masterKeyBytes)
 
@@ -66,12 +65,8 @@ func MasterKeyContext(ctx context.Context) ([MasterKeyLength]byte, error) {
 	return masterKey, nil
 }
 
-// TransferMasterKeyContext passes the master key saved in the base context to a
-// new context derived from the destination context. It returns the newly created
-// context.
-//
-// If the base context does not contain any master key, this is a no-op, and the
-// destination context is returned as-is.
+// TransferMasterKeyContext copies the master key held by baseCtx onto a context derived from
+// destCtx. When baseCtx holds no master key, destCtx is returned unchanged.
 func TransferMasterKeyContext(baseCtx, destCtx context.Context) context.Context {
 	masterKey, ok := baseCtx.Value(masterKeyContext{}).([MasterKeyLength]byte)
 	if !ok {

--- a/internal/models/migrations/20260722072945_initial_schema.up.sql
+++ b/internal/models/migrations/20260722072945_initial_schema.up.sql
@@ -20,8 +20,8 @@ CREATE INDEX keys_usage_idx ON keys (usage);
 
 /* active_keys exposes only keys that are still valid, and is the only object DAOs read from.
 
-Both conditions are required: testing COALESCE(deleted_at, expires_at) would let a future
-deleted_at act as a backdoor expiry for a key whose expires_at has already passed.
+Both conditions are required. deleted_at and expires_at are independent, and a COALESCE over
+the pair lets a future deleted_at mask an expires_at that has already passed.
 
 Being a plain view, the predicates are evaluated per query, so a key stops being served the moment
 its expires_at passes or its deleted_at is set. */

--- a/internal/models/migrations/20260722072945_initial_schema.up.sql
+++ b/internal/models/migrations/20260722072945_initial_schema.up.sql
@@ -1,13 +1,4 @@
--- Baseline schema, squashed from the four migrations that preceded it.
---
--- Those four ended at exactly this state, so the history carried no information the schema below
--- does not — only a dependency: one of them scheduled a pg_cron job, which forced every database
--- to have the extension installed purely so the history could replay. Squashing removes the last
--- reference to pg_cron and lets the database image drop it.
---
--- Safe to do here only because nothing is deployed. A database that already ran the old set has no
--- row for this version, so it will try to apply it and fail on the existing table — loudly, which
--- is the intent. Recreate such a database rather than patching around it.
+-- Baseline schema: the keys table and the active_keys view every DAO reads through.
 CREATE TABLE keys (
   id uuid PRIMARY KEY NOT NULL,
   /* Encrypted private key in JSON Web Key format, base64url-encoded. */
@@ -29,12 +20,11 @@ CREATE INDEX keys_usage_idx ON keys (usage);
 
 /* active_keys exposes only keys that are still valid, and is the only object DAOs read from.
 
-Both conditions are required. Testing COALESCE(deleted_at, expires_at) instead would let a
-deleted_at in the future act as a backdoor expiry for a key whose expires_at has already passed.
+Both conditions are required: testing COALESCE(deleted_at, expires_at) would let a future
+deleted_at act as a backdoor expiry for a key whose expires_at has already passed.
 
-It is a plain view, so the predicates are evaluated per query: a key stops being served the moment
-its expires_at passes or its deleted_at is set. Materializing it froze both into a periodic
-snapshot, which meant revocation did not take effect until the next refresh. */
+Being a plain view, the predicates are evaluated per query, so a key stops being served the moment
+its expires_at passes or its deleted_at is set. */
 CREATE VIEW active_keys AS (
   SELECT
     *

--- a/internal/models/proto/jwk_list.proto
+++ b/internal/models/proto/jwk_list.proto
@@ -2,8 +2,7 @@ syntax = "proto3";
 
 import "jwk.proto";
 
-// JwkListService lists the active keys for a given usage, newest first: the first key is
-// the current signing key, the rest are older keys still trusted for verification.
+// JwkListService lists the active public keys for a given usage.
 service JwkListService {
   // Returns the active public keys for the given usage, newest first. The first key is the
   // current signing key; the rest are older keys still trusted for verifying tokens issued

--- a/internal/models/proto/status.proto
+++ b/internal/models/proto/status.proto
@@ -21,7 +21,7 @@ enum DependencyStatus {
 
 // DependencyHealth reports the health of a single external dependency.
 //
-// The message carries the status alone: health-check errors embed internal hostnames, ports and
+// The message carries the status alone. Health-check errors embed internal hostnames, ports and
 // schema names, and this gRPC surface may not stay internal forever. The underlying error is
 // recorded on the trace span for operators.
 message DependencyHealth {

--- a/internal/models/proto/status.proto
+++ b/internal/models/proto/status.proto
@@ -21,13 +21,11 @@ enum DependencyStatus {
 
 // DependencyHealth reports the health of a single external dependency.
 //
-// The shape is deliberately minimal. This gRPC surface is internal today, but errors from a
-// dependency health check routinely embed internal hostnames, ports, or schema names, and
-// carrying them in the response would leak infrastructure topology if it ever became
-// externally reachable. The underlying error is recorded on the trace span for operators.
+// The message carries the status alone: health-check errors embed internal hostnames, ports and
+// schema names, and this gRPC surface may not stay internal forever. The underlying error is
+// recorded on the trace span for operators.
 message DependencyHealth {
-  // Number 2 and name "err" are reserved so a future field cannot re-introduce a raw error
-  // string, which would re-open the topology leak this message is shaped to avoid.
+  // Reserved so a future field cannot re-introduce a raw error string and re-open the leak.
   reserved 2;
   reserved "err";
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -176,10 +176,9 @@ components:
     healthStatus:
       type: object
       description: |
-        Status of a single dependency entry, as observed by the server. The shape is
-        intentionally minimal so that an unauthenticated caller cannot infer
-        infrastructure details from a degraded dependency; richer diagnostics are
-        recorded on server-side traces.
+        Status of a single dependency entry, as observed by the server. The body carries the
+        status alone, so an unauthenticated caller cannot infer infrastructure details from a
+        degraded dependency; richer diagnostics are recorded on server-side traces.
       required: [status]
       additionalProperties: false
       examples:

--- a/pkg/go/claims.go
+++ b/pkg/go/claims.go
@@ -56,8 +56,8 @@ type claimsVerifier[C any] struct {
 // configuration references an unsupported algorithm. C must be JSON-serializable and match the
 // claims type used when signing for the same usage.
 func NewClaimsVerifier[C any](c Client) (ClaimsVerifier[C], error) {
-	// Build the cached public-key sources here rather than in the client, so the client's exported
-	// surface never mentions a jwt type. A sign-only consumer that never calls this pays nothing.
+	// Building the public-key sources here keeps jwt types off the client's exported surface,
+	// and a sign-only consumer never pays for the setup.
 	adapter := newJwkExportGrpc(c)
 
 	sources, err := core.NewJwkPublicSource(adapter, c.Keys())

--- a/pkg/go/client.go
+++ b/pkg/go/client.go
@@ -57,9 +57,8 @@ type BaseClient interface {
 
 // Client extends [BaseClient] with the JWK configuration needed to build local token verifiers.
 //
-// Obtain a Client with [NewClient]. Pass it to [NewClaimsVerifier], which builds the cached
-// public-key sources for local verification — so the client's own exported surface stays free of
-// jwt types, and a sign-only consumer never pays for verifier setup.
+// Obtain a Client with [NewClient], then pass it to [NewClaimsVerifier], which builds the
+// cached public-key sources used for local verification.
 type Client interface {
 	BaseClient
 

--- a/pkg/js/rest/src/api.ts
+++ b/pkg/js/rest/src/api.ts
@@ -19,8 +19,7 @@ export type HealthDependency = {
  *
  * The REST API is the public read-only interface of the JSON-keys service. It exposes
  * JSON Web Key endpoints so that any client can fetch public keys for local token
- * verification. Signing and private key operations are not available over REST — those
- * are handled by the private gRPC API.
+ * verification. Signing and private key operations live on the private gRPC API.
  */
 export class JsonKeysApi {
   private readonly _baseUrl: string;


### PR DESCRIPTION
## Summary

- Comment-only sweep: cut verbosity, replace contrastive framing ("X, not Y") with the positive claim, and drop justification of rejected alternatives in favour of what the code does today.
- 122 insertions / 198 deletions across 33 files. Security and format facts were treated as load-bearing and only compressed — master-key encryption at rest, "private key material never leaves the server", secretbox nonce and overhead sizes, and master-key rotation invalidating stored private keys all survive.

## What a reviewer should scrutinise

- **`internal/core/jwkRotateAll.go` had become a changelog.** Five lines described a previous design in which each key committed on its own and a failure on the third usage left the first two rotated. That code is gone; the doc now states the invariant that holds — the injected transactor wraps the whole rotation, so a partial failure leaves nothing rotated. Worth confirming that reading matches the transactor wiring.
- **The initial-schema migration header** was ten lines about the squash that produced the file — pg_cron history, "safe only because nothing is deployed", and recovery steps for an already-migrated database. Cut to one orienting line.
- **`active_keys` deliberately keeps its counter-example.** The `COALESCE(deleted_at, expires_at)` note stays, because that is the substitution a reader would plausibly reach for and it opens a backdoor expiry. Everything around it was trimmed, including a past-tense clause about the view once being materialised.
- **`internal/dao/pg.jwk.go`'s `Usage` field** went from four paragraphs to two while keeping the whole producer/recipient/main/legacy taxonomy.

## Known drift, not addressed here

`openapi.yaml` and `pkg/js/rest/src/api.ts` both declare an `err` field on the health-status schema that the Go handler deliberately withholds. Correcting it changes a published contract, so it is out of scope for a comment sweep — flagging it for a follow-up. The same drift exists in `service-template`, which is where it originates.

## Breaking changes

None. No exported symbol, signature or behaviour changed.

## Test plan

- [x] `gofmt -l .` clean, `go build ./...` passes
- [x] `go tool -modfile=golangci-lint.mod golangci-lint run ./...` — 0 issues
- [x] Pre-existing `internal/handlers` / `pkg/go` test failures confirmed identical on the pre-sweep tree (they need a live DB and a running service)
- [ ] CI green