### PR TITLE
docs: sweep counterfactuals the earlier pass missed

### DIFF
--- a/internal/core/jwkRotateAll_test.go
+++ b/internal/core/jwkRotateAll_test.go
@@ -54,9 +54,8 @@ func TestJwkRotateAllProcessesEveryUsage(t *testing.T) {
 	require.Equal(t, 1, transactor.Calls(), "every usage belongs to one unit of work, not one each")
 }
 
-// TestRotateKeysReportsNothingProcessedOnFailure covers the count's contract: a
-// partial number describes work that has been rolled back, so reporting it would
-// tell an operator that keys were rotated when none were.
+// TestRotateKeysReportsNothingProcessedOnFailure covers the count's contract. A partial
+// number describes work that has been rolled back, so the count reports zero.
 func TestJwkRotateAllReportsNothingProcessedOnFailure(t *testing.T) {
 	t.Parallel()
 

--- a/internal/dao/pg.jwkDelete_test.go
+++ b/internal/dao/pg.jwkDelete_test.go
@@ -187,14 +187,11 @@ func TestPgJwkDelete(t *testing.T) {
 	}
 }
 
-// TestPgJwkDeleteTakesEffectImmediately is the regression this milestone's issue is about: a
-// revoked key must stop being served from the moment it is revoked, with no refresh in between.
+// TestPgJwkDeleteTakesEffectImmediately pins that a revoked key stops being served from the
+// moment it is revoked, with no refresh in between.
 //
-// It reads through PgJwkSelect rather than asserting on the delete's own return value, because
-// the defect lived entirely on the read path. While active_keys was a materialized view the
-// snapshot carried a *copy* of deleted_at, so the revoked key kept being returned — and kept
-// signing — until the next hourly refresh. Nothing the reader could filter on would have caught
-// it, since the stale column was in the snapshot itself.
+// It reads through PgJwkSelect, because the guarantee lives on the read path: active_keys is a
+// plain view, so its predicates are evaluated per query and a revocation takes effect at once.
 func TestPgJwkDeleteTakesEffectImmediately(t *testing.T) {
 	t.Parallel()
 
@@ -229,8 +226,7 @@ func TestPgJwkDeleteTakesEffectImmediately(t *testing.T) {
 
 			selectDAO := dao.NewPgJwkSelect()
 
-			// Precondition: the key is served before revocation. Without this the test would
-			// still pass against a read path that returns nothing at all.
+			// Precondition: the key is served before revocation.
 			got, err := selectDAO.Exec(ctx, &dao.JwkSelectRequest{ID: keyID})
 			require.NoError(t, err)
 			require.Equal(t, keyID, got.ID)


### PR DESCRIPTION
## Summary

Follow-up to the comment sweep. The earlier pass verified itself against its own diff, so comments it chose not to rewrite were never re-checked once the bar tightened to "no counterfactuals, affirmative sentences". This is the tree-wide re-scan.

Three comments, of which one is worth reading closely.

- **`internal/dao/pg.jwkDelete_test.go`** — the test's doc was mostly archaeology: it named the milestone issue it came from, then described the materialized-view design that no longer exists and what that design used to do wrong. Replaced with what the test pins today and why it reads through `PgJwkSelect`: `active_keys` is a plain view, so its predicates are evaluated per query and a revocation takes effect at once. The nested precondition comment lost its "without this the test would still pass against …" defence.
- `internal/core/jwkRotateAll_test.go` — "so reporting it would tell an operator that keys were rotated when none were" → the count reports zero.

## Not touched

`redocly.yaml`'s comment carries the same shape, but the file is tool config and its documentation belongs to Redocly.

## Breaking changes

None.

## Test plan

- [x] `gofmt -l .` clean, `go build ./...` passes
- [x] `go tool -modfile=golangci-lint.mod golangci-lint run ./...` — 0 issues
- [x] diff contains no non-comment lines
- [ ] CI green