### PR TITLE
fix(config): bound the database connection pool

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,13 @@ REST tuning (images `rest`, `standalone-rest`):
 | `REST_CORS_ALLOW_CREDENTIALS` | CORS allow-credentials flag.         | `false`          |
 | `REST_CORS_MAX_AGE`           | CORS max-age, in seconds.            | `3600`           |
 
+Database connection pool (server images). The limits are **per process**: what must stay under the database's `max_connections` is the sum across every replica plus the migration job, not one replica's number. The stock `postgres` default is 100.
+
+| Name                      | Description                               | Default |
+| ------------------------- | ----------------------------------------- | ------- |
+| `POSTGRES_MAX_OPEN_CONNS` | Maximum open connections to the database. | `20`    |
+| `POSTGRES_MAX_IDLE_CONNS` | Maximum connections kept open while idle. | `20`    |
+
 Logs and tracing — OpenTelemetry supports a stdout and a Google Cloud exporter (all server images):
 
 | Name                | Description                                                           | Default             |

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ REST tuning (images `rest`, `standalone-rest`):
 | `REST_CORS_ALLOW_CREDENTIALS` | CORS allow-credentials flag.         | `false`          |
 | `REST_CORS_MAX_AGE`           | CORS max-age, in seconds.            | `3600`           |
 
-Database connection pool (server images). The limits are **per process**: what must stay under the database's `max_connections` is the sum across every replica plus the migration job, not one replica's number. The stock `postgres` default is 100.
+Database connection pool (server images). The limits are **per process**. The database's `max_connections` has to cover every replica plus the migration job; the stock `postgres` default is 100.
 
 | Name                      | Description                               | Default |
 | ------------------------- | ----------------------------------------- | ------- |

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/a-novel/service-json-keys/v2
 go 1.26.5
 
 require (
-	github.com/a-novel-kit/golib v0.24.0
+	github.com/a-novel-kit/golib v0.25.1
 	github.com/a-novel-kit/jwt/v2 v2.0.1
 	github.com/go-chi/chi/v5 v5.3.1
 	github.com/go-chi/cors v1.2.2

--- a/go.sum
+++ b/go.sum
@@ -23,8 +23,8 @@ github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapp
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.58.0/go.mod h1:YqwkQPrWSC7+byyc1VlKbWLBF5JsW5IoL6xUkemYSXk=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/propagator v0.58.0 h1:p4AShSHj73soQNs4j0aowCWmMqiCN5sEF6d18Hw6vbA=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/propagator v0.58.0/go.mod h1:gW2WKecnAdBKF4E64jL86UXyvVcsPnNunINOq72OLMk=
-github.com/a-novel-kit/golib v0.24.0 h1:nmCq+3x15gL1VZMgqDfRp1Ao7n9shh55o3CnHk/8d+s=
-github.com/a-novel-kit/golib v0.24.0/go.mod h1:vjhtCNpNAYN5fjSBEDBMy8hZXbr8I8tPCPKSBzh0GPs=
+github.com/a-novel-kit/golib v0.25.1 h1:BjbSIQSAazwg0CWDcsKPJE2nM0tgWo8O3YgefqXZFUA=
+github.com/a-novel-kit/golib v0.25.1/go.mod h1:vjhtCNpNAYN5fjSBEDBMy8hZXbr8I8tPCPKSBzh0GPs=
 github.com/a-novel-kit/jwt/v2 v2.0.1 h1:+sbGA8kTgTJjsUvFI255ztWENjwWdSpqXdqgLK13WPg=
 github.com/a-novel-kit/jwt/v2 v2.0.1/go.mod h1:QLLGdh58mLRNb0SiRCrYww2EJrdyaMSVKPn3jovPEQg=
 github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=

--- a/internal/config/env/env.go
+++ b/internal/config/env/env.go
@@ -32,6 +32,16 @@ const (
 	RestMaxRequestSizeDefault    = 2 << 20 // 2 MiB
 	CorsAllowCredentialsDefault  = false
 	CorsMaxAgeDefault            = 3600
+
+	// PostgresMaxOpenConnsDefault keeps the pool well under a stock PostgreSQL
+	// max_connections of 100 once multiplied by a service's replica count, leaving
+	// room for the migration job and a psql session. Go's own default is unlimited,
+	// which turns a spike into connection refusals for everything on that database
+	// rather than queueing inside this process.
+	PostgresMaxOpenConnsDefault = 20
+	// PostgresMaxIdleConnsDefault matches the open limit so a burst does not close
+	// connections it is about to reopen.
+	PostgresMaxIdleConnsDefault = 20
 )
 
 // Default values used when the corresponding environment variable is absent.
@@ -42,7 +52,9 @@ var (
 
 // Raw values for environment variables.
 var (
-	postgresDsn = getEnv("POSTGRES_DSN")
+	postgresDsn          = getEnv("POSTGRES_DSN")
+	postgresMaxOpenConns = getEnv("POSTGRES_MAX_OPEN_CONNS")
+	postgresMaxIdleConns = getEnv("POSTGRES_MAX_IDLE_CONNS")
 
 	appName      = getEnv("APP_NAME")
 	appMasterKey = getEnv("APP_MASTER_KEY")
@@ -72,6 +84,11 @@ var (
 	// PostgresDsn is the URL used to connect to the Postgres database instance:
 	//	postgres://<user>:<password>@<host>:<port>/<database>
 	PostgresDsn = postgresDsn
+
+	// PostgresMaxOpenConns is the maximum number of open connections to the database.
+	PostgresMaxOpenConns = config.LoadEnv(postgresMaxOpenConns, PostgresMaxOpenConnsDefault, config.IntParser)
+	// PostgresMaxIdleConns is the maximum number of connections kept open while idle.
+	PostgresMaxIdleConns = config.LoadEnv(postgresMaxIdleConns, PostgresMaxIdleConnsDefault, config.IntParser)
 
 	// AppName is the application name, as it appears in logs and tracing.
 	AppName = config.LoadEnv(appName, AppNameDefault, config.StringParser)

--- a/internal/config/postgres.config.default.go
+++ b/internal/config/postgres.config.default.go
@@ -9,4 +9,18 @@ import (
 )
 
 // PostgresPresetDefault is the default PostgreSQL configuration populated from environment variables.
-var PostgresPresetDefault = postgrespresets.NewDefault(pgdriver.WithDSN(env.PostgresDsn))
+var PostgresPresetDefault = newPostgresPreset()
+
+// newPostgresPreset builds the connection config with its pool bounded.
+//
+// The limits belong here rather than on the pool the config hands out: that
+// handle is cached, so setting them afterwards only takes effect if it happens
+// before anything else asks for a connection — an order nothing enforces, and
+// missing it applies them to nothing without an error.
+func newPostgresPreset() *postgrespresets.Default {
+	preset := postgrespresets.NewDefault(pgdriver.WithDSN(env.PostgresDsn))
+	preset.MaxOpenConns = env.PostgresMaxOpenConns
+	preset.MaxIdleConns = env.PostgresMaxIdleConns
+
+	return preset
+}

--- a/internal/config/postgres.config.default.go
+++ b/internal/config/postgres.config.default.go
@@ -11,11 +11,11 @@ import (
 // PostgresPresetDefault is the default PostgreSQL configuration populated from environment variables.
 var PostgresPresetDefault = newPostgresPreset()
 
-// newPostgresPreset builds the connection config with its pool bounded.
+// newPostgresPreset builds the connection config with its pool bounded as it opens.
 //
-// The pool is bounded as it opens. Setting the limits on the handle afterwards
-// stops working once anything has taken a connection, because the handle is
-// cached, and past that point they apply to nothing and report nothing.
+// Setting the limits on the handle afterwards stops working once anything has
+// taken a connection, because the handle is cached; past that point they apply to
+// nothing and report nothing.
 func newPostgresPreset() *postgrespresets.Default {
 	preset := postgrespresets.NewDefault(pgdriver.WithDSN(env.PostgresDsn))
 	preset.MaxOpenConns = env.PostgresMaxOpenConns

--- a/internal/config/postgres.config.default.go
+++ b/internal/config/postgres.config.default.go
@@ -13,10 +13,9 @@ var PostgresPresetDefault = newPostgresPreset()
 
 // newPostgresPreset builds the connection config with its pool bounded.
 //
-// The limits belong here rather than on the pool the config hands out: that
-// handle is cached, so setting them afterwards only takes effect if it happens
-// before anything else asks for a connection — an order nothing enforces, and
-// missing it applies them to nothing without an error.
+// The pool is bounded as it opens. Setting the limits on the handle afterwards
+// stops working once anything has taken a connection, because the handle is
+// cached, and past that point they apply to nothing and report nothing.
 func newPostgresPreset() *postgrespresets.Default {
 	preset := postgrespresets.NewDefault(pgdriver.WithDSN(env.PostgresDsn))
 	preset.MaxOpenConns = env.PostgresMaxOpenConns


### PR DESCRIPTION
Bounds the connection pool. `database/sql` defaults `MaxOpenConns` to 0, so enough replicas exhaust the database, and the error lands on whichever process asks next — the migration job, an operator’s `psql`.

Closes #826

## Where the limits live

On the connection config, applied as the pool opens. Setting them on the handle afterwards stops working once anything has taken a connection, because the handle is cached; past that point they apply to nothing and report nothing.

Requires golib v0.25.1, which added the fields. `main` is untouched.

## Numbers

Per process, so the budget is `replicas × max_open + jobs < max_connections`, against a stock 100. Defaults are 20/20, both environment variables.