### PR TITLE
[SCRATCH] activation-snapshot rehearsal — DO NOT MERGE

### DIFF
--- a/REHEARSAL_SCRATCH.md
+++ b/REHEARSAL_SCRATCH.md
@@ -1,0 +1,7 @@
+# SCRATCH -- activation-snapshot rehearsal
+
+Do not merge. Delete with a-novel/.github#215.
+
+*   This file is intentionally formatted so `lint-node` fails.
+*   A red required check is what keeps this pull request open: an all-ready Epic member has
+    auto-merge armed, so without it the set merges before the reconcile sweep can observe it.


### PR DESCRIPTION
Throwaway. Member of the scratch Epic a-novel/.github#215, rehearsing the activation-snapshot capture (a-novel-kit/workflows#321, v1.22.0).

`lint-node` fails on purpose. That is what keeps this open: `merge-gate` treats a member as ready on **non-draft + approved** alone, and `merge-gate-run.yaml` arms auto-merge on every labeled non-draft member, so a green all-ready set merges itself within minutes — before the 15-minute reconcile sweep can observe it and report what it would capture.

Close this and delete the branch once the capture has been read.