### PR TITLE
fix(core): report a reserved claim as a client error, not a fault

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26.5
 
 require (
 	github.com/a-novel-kit/golib v0.25.1
-	github.com/a-novel-kit/jwt/v2 v2.1.0
+	github.com/a-novel-kit/jwt/v2 v2.2.1
 	github.com/go-chi/chi/v5 v5.3.1
 	github.com/go-chi/cors v1.2.2
 	github.com/goccy/go-yaml v1.19.2

--- a/go.sum
+++ b/go.sum
@@ -25,8 +25,8 @@ github.com/GoogleCloudPlatform/opentelemetry-operations-go/propagator v0.58.0 h1
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/propagator v0.58.0/go.mod h1:gW2WKecnAdBKF4E64jL86UXyvVcsPnNunINOq72OLMk=
 github.com/a-novel-kit/golib v0.25.1 h1:BjbSIQSAazwg0CWDcsKPJE2nM0tgWo8O3YgefqXZFUA=
 github.com/a-novel-kit/golib v0.25.1/go.mod h1:vjhtCNpNAYN5fjSBEDBMy8hZXbr8I8tPCPKSBzh0GPs=
-github.com/a-novel-kit/jwt/v2 v2.1.0 h1:389B6frLT5YwE6bkZYdfrH/QFy3Qf8xGVDiiDCeUpdk=
-github.com/a-novel-kit/jwt/v2 v2.1.0/go.mod h1:QLLGdh58mLRNb0SiRCrYww2EJrdyaMSVKPn3jovPEQg=
+github.com/a-novel-kit/jwt/v2 v2.2.1 h1:Oqu29DG6k9/v3Eo3uLpYPCGP1c8xp4cFcjaVlUpR4oM=
+github.com/a-novel-kit/jwt/v2 v2.2.1/go.mod h1:QLLGdh58mLRNb0SiRCrYww2EJrdyaMSVKPn3jovPEQg=
 github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=
 github.com/cenkalti/backoff/v5 v5.0.3/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=

--- a/internal/core/claimsSign.go
+++ b/internal/core/claimsSign.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"go.opentelemetry.io/otel/attribute"
@@ -70,7 +71,14 @@ func (service *ClaimsSign) Exec(ctx context.Context, request *ClaimsSignRequest)
 
 	producer := jwt.NewProducer(jwt.ProducerConfig{Plugins: producerPlugins})
 
+	// A caller claim that collides with the envelope above is rejected at
+	// encoding time, inside Issue. The request is malformed, so it is classified
+	// rather than reported as a fault; the wrapped error names the members.
 	token, err := producer.Issue(ctx, claims, nil)
+	if errors.Is(err, jwa.ErrReservedMember) {
+		return "", fmt.Errorf("%w: %w", ErrReservedClaim, err)
+	}
+
 	if err != nil {
 		return "", otel.ReportError(span, fmt.Errorf("issue token: %w", err))
 	}

--- a/internal/core/claimsSign_test.go
+++ b/internal/core/claimsSign_test.go
@@ -73,6 +73,36 @@ func TestClaimsSign(t *testing.T) {
 
 			expectErr: core.ErrConfigNotFound,
 		},
+		{
+			// The envelope's own claims are stamped from the usage config, so a
+			// caller naming one is refused when the token is encoded. A usage
+			// registered with no plugins still reaches that point, which is where
+			// the claims are serialized.
+			name: "Error/ReservedClaim",
+
+			request: &core.ClaimsSignRequest{
+				Claims: map[string]any{"sub": "attacker", "foo": "bar"},
+				Usage:  "test-usage",
+			},
+
+			keysConfig: testConfig,
+			producers:  core.JwkProducers{"test-usage": nil},
+
+			expectErr: core.ErrReservedClaim,
+		},
+		{
+			name: "Success/UnreservedClaims",
+
+			request: &core.ClaimsSignRequest{
+				Claims: &testClaims{Foo: "bar"},
+				Usage:  "test-usage",
+			},
+
+			keysConfig: testConfig,
+			producers:  core.JwkProducers{"test-usage": nil},
+
+			expectErr: nil,
+		},
 	}
 
 	for _, testCase := range testCases {

--- a/internal/core/common.go
+++ b/internal/core/common.go
@@ -7,3 +7,9 @@ var ErrConfigNotFound = errors.New("no config found for the requested usage")
 
 // ErrJwkNotFound is returned when no active key matches the requested ID.
 var ErrJwkNotFound = errors.New("jwk not found")
+
+// ErrReservedClaim is returned when the caller's claims name a registered JWT
+// parameter. Those belong to the envelope the service stamps from the usage
+// config, so a caller setting one is asking for a token that contradicts the
+// terms it was signed under. It reports a malformed request, not a fault.
+var ErrReservedClaim = errors.New("claims may not set a registered JWT parameter")

--- a/internal/handlers/grpc.claimsSign.go
+++ b/internal/handlers/grpc.claimsSign.go
@@ -52,6 +52,14 @@ func (handler *GrpcClaimsSign) ClaimsSign(
 		return nil, status.Error(codes.Unavailable, "unknown usage")
 	}
 
+	// The registered claims belong to the usage's envelope. Naming the set keeps
+	// the caller from having to guess which of their claims was refused, without
+	// echoing the service's own error text back to them.
+	if errors.Is(err, core.ErrReservedClaim) {
+		return nil, status.Error(codes.InvalidArgument,
+			"payload may not set a registered claim (iss, sub, aud, exp, nbf, iat, jti)")
+	}
+
 	if err != nil {
 		_ = otel.ReportError(span, err)
 

--- a/internal/handlers/grpc.claimsSign_test.go
+++ b/internal/handlers/grpc.claimsSign_test.go
@@ -38,6 +38,9 @@ func TestGrpcClaimsSign(t *testing.T) {
 
 		expect       *protogen.ClaimsSignResponse
 		expectStatus codes.Code
+		// expectMessage is a fragment the status message must carry, so a caller
+		// can tell what to fix without reading the service's logs.
+		expectMessage string
 	}{
 		{
 			name: "Success",
@@ -83,6 +86,25 @@ func TestGrpcClaimsSign(t *testing.T) {
 			expectStatus: codes.Unavailable,
 		},
 		{
+			// A caller naming a registered claim sent a bad request. Reporting it
+			// as Internal would blame the service for the caller's input and give
+			// them nothing to correct.
+			name: "Error/ReservedClaim",
+
+			request: &protogen.ClaimsSignRequest{
+				Payload: lo.Must(grpcf.MarshalJSONAsAny(map[string]any{"sub": "attacker"})),
+				Usage:   "test-usage",
+			},
+
+			serviceMock: &serviceMock{
+				req: map[string]any{"sub": "attacker"},
+				err: core.ErrReservedClaim,
+			},
+
+			expectStatus:  codes.InvalidArgument,
+			expectMessage: "registered claim",
+		},
+		{
 			name: "Error/Internal",
 
 			request: &protogen.ClaimsSignRequest{
@@ -124,6 +146,11 @@ func TestGrpcClaimsSign(t *testing.T) {
 				testCase.expectStatus, resSt.Code(),
 				"expected status code %s, got %s (%v)", testCase.expectStatus, resSt.Code(), err,
 			)
+
+			if testCase.expectMessage != "" {
+				require.Contains(t, resSt.Message(), testCase.expectMessage)
+			}
+
 			require.Equal(t, testCase.expect, res)
 
 			service.AssertExpectations(t)

--- a/internal/handlers/protogen/claims_sign.pb.go
+++ b/internal/handlers/protogen/claims_sign.pb.go
@@ -31,6 +31,11 @@ type ClaimsSignRequest struct {
 	Usage string `protobuf:"bytes,1,opt,name=usage,proto3" json:"usage,omitempty"`
 	// The claims payload to embed in the token. Its inner type should remain consistent for
 	// a given usage.
+	//
+	// The registered claims — iss, sub, aud, exp, nbf, iat, jti — belong to the envelope the
+	// server stamps from the usage config, and naming one here is rejected rather than
+	// applied. Verification checks the server's values, so a token carrying the caller's
+	// would not verify.
 	Payload       *anypb.Any `protobuf:"bytes,2,opt,name=payload,proto3" json:"payload,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache

--- a/internal/handlers/protogen/claims_sign_grpc.pb.go
+++ b/internal/handlers/protogen/claims_sign_grpc.pb.go
@@ -31,7 +31,8 @@ const (
 type ClaimsSignServiceClient interface {
 	// Signs the provided claims and returns a compact JWT. The signing key and all token
 	// parameters are determined by the requested usage. Returns UNAVAILABLE if the usage is
-	// not configured on the server.
+	// not configured on the server, and INVALID_ARGUMENT if the payload names a registered
+	// claim.
 	ClaimsSign(ctx context.Context, in *ClaimsSignRequest, opts ...grpc.CallOption) (*ClaimsSignResponse, error)
 }
 
@@ -62,7 +63,8 @@ func (c *claimsSignServiceClient) ClaimsSign(ctx context.Context, in *ClaimsSign
 type ClaimsSignServiceServer interface {
 	// Signs the provided claims and returns a compact JWT. The signing key and all token
 	// parameters are determined by the requested usage. Returns UNAVAILABLE if the usage is
-	// not configured on the server.
+	// not configured on the server, and INVALID_ARGUMENT if the payload names a registered
+	// claim.
 	ClaimsSign(context.Context, *ClaimsSignRequest) (*ClaimsSignResponse, error)
 	mustEmbedUnimplementedClaimsSignServiceServer()
 }

--- a/internal/models/proto/claims_sign.proto
+++ b/internal/models/proto/claims_sign.proto
@@ -7,7 +7,8 @@ import "google/protobuf/any.proto";
 service ClaimsSignService {
   // Signs the provided claims and returns a compact JWT. The signing key and all token
   // parameters are determined by the requested usage. Returns UNAVAILABLE if the usage is
-  // not configured on the server.
+  // not configured on the server, and INVALID_ARGUMENT if the payload names a registered
+  // claim.
   rpc ClaimsSign(ClaimsSignRequest) returns (ClaimsSignResponse);
 }
 
@@ -19,6 +20,11 @@ message ClaimsSignRequest {
   string usage = 1;
   // The claims payload to embed in the token. Its inner type should remain consistent for
   // a given usage.
+  //
+  // The registered claims — iss, sub, aud, exp, nbf, iat, jti — belong to the envelope the
+  // server stamps from the usage config, and naming one here is rejected rather than
+  // applied. Verification checks the server's values, so a token carrying the caller's
+  // would not verify.
   google.protobuf.Any payload = 2;
 }
 

--- a/pkg/go/client.go
+++ b/pkg/go/client.go
@@ -49,6 +49,10 @@ type BaseClient interface {
 	// ClaimsSign asks the service to sign claims and returns a compact JWT.
 	// The request payload must be a protobuf Any wrapping the claims to embed;
 	// the response token is the resulting compact JWT string.
+	//
+	// The payload carries application claims only. The registered ones — iss,
+	// sub, aud, exp, nbf, iat, jti — come from the usage's server-side config,
+	// and a payload naming one fails with InvalidArgument.
 	ClaimsSign(ctx context.Context, req *ClaimsSignRequest, opts ...grpc.CallOption) (*ClaimsSignResponse, error)
 
 	// Close releases the underlying gRPC connection. Typically called via defer after NewClient.


### PR DESCRIPTION
Closes #860, and carries the `a-novel-kit/jwt` bump the classification depends on.

## Why the two are one change

`jwa.ErrReservedMember` does not exist before jwt v2.2.0, so the mapping cannot land without the bump — and the bump should not land without the mapping, or the window between them is exactly the failure #860 describes.

## The classification

`core/claimsSign.go:54` passes `request.Claims` into the signer. That field is `any` and documented as *"Any JSON-serializable value is accepted"*. jwt now rejects a claim naming a registered parameter — `iss`, `sub`, `aud`, `exp`, `nbf`, `iat`, `jti` — which this service stamps itself from the usage config.

Unclassified, that rejection lands on `otel.ReportError` → generic failure → the caller gets an internal fault for a request only they can fix, and the service records a failure it did not have.

Now: `ErrReservedClaim` wrapping the library error, and `codes.InvalidArgument` from the handler naming the registered set. The names come from the caller's own payload, so nothing is disclosed that they did not send.

The error is deliberately **not** passed through `otel.ReportError` — it is a malformed request, and `ErrConfigNotFound` right above it already sets that precedent.

## ⚠️ The bump is to v2.2.1, not v2.2.0

v2.2.0 shipped a round-trip regression (a-novel-kit/jwt#495): `UnmarshalPartial` returned the source object whole, so re-encoding a decoded `JWK` was rejected as an override of the value it was read from. **This repo is what caught it** — `TestJwkExtract` fails against v2.2.0 with

```
json: error calling MarshalJSON for type *jwa.JWK:
(MarshalPartial) custom payload may not set a registered member: alg, key_ops, kid, kty
```

which is the public key endpoints going down. Fixed in **v2.2.1**; `internal/core` is green against it.

If a Renovate PR proposing **v2.2.0** shows up, close it in favour of this one.

## Correction to the issue

#860 asked for "an `openapi.yaml` response to match". There isn't one to add — signing is **gRPC-only**. `openapi.yaml` says so itself: *"To sign tokens, use the internal gRPC API."* REST exposes public key retrieval only, and there is no `rest.claimsSign.go`. I've amended the issue.

## Documentation

The contract was only discoverable by reading the service. Both consumer-facing surfaces now state it:

- `internal/models/proto/claims_sign.proto` — `INVALID_ARGUMENT` on the RPC, and on `payload`, which claims are the envelope's and why a token carrying the caller's would not verify anyway.
- `pkg/go/client.go` — the same on `ClaimsSign`, which is what a consuming service actually reads.

## Verification

Red check — against the unclassified code:

```
--- FAIL: TestClaimsSign/Error/ReservedClaim
--- FAIL: TestGrpcClaimsSign/Error/ReservedClaim
```

The core case needed no signing key: a usage registered with an empty plugin list still reaches the claims serialization, which is where the rejection happens. `Success/UnreservedClaims` pins that an ordinary payload is unaffected, and the handler case asserts the *message* carries the registered set, not just the code — a bare `InvalidArgument` would leave the caller no better off.

`internal/core` and `internal/handlers` green, `golangci-lint` 0 issues, `buf lint` clean, `go generate` idempotent.

`pkg/go`'s `TestClient` / `TestClaimsVerifier` fail locally for want of a service address — identical on master, unrelated. They run in CI's `test-pkg` lane.
