### PR TITLE
chore(ci): drop the go-report-card job and README badge

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -430,16 +430,6 @@ jobs:
           client_id: ${{ vars.DEPENDENCY_BOT_CLIENT_ID }}
           build_action: "build:rest"
 
-  report-grc:
-    runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/master' && success()
-    needs: [test-go, test-pkg]
-    permissions:
-      contents: read
-    steps:
-      - uses: a-novel-kit/workflows/go-actions/go-report-card@v1.23.0
-        if: github.ref == 'refs/heads/master' && success()
-
   report-codecov:
     runs-on: ubuntu-latest
     needs: [test-go, test-pkg, test-pkg-js]

--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ Centralized signing-key manager for the A-Novel platform: it holds every private
 ![GitHub code size in bytes](https://img.shields.io/github/languages/code-size/a-novel/service-json-keys)
 
 ![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/a-novel/service-json-keys/main.yaml)
-[![Go Report Card](https://goreportcard.com/badge/github.com/a-novel/service-json-keys)](https://goreportcard.com/report/github.com/a-novel/service-json-keys)
 [![codecov](https://codecov.io/gh/a-novel/service-json-keys/graph/badge.svg)](https://codecov.io/gh/a-novel/service-json-keys)
 
 ![Coverage graph](https://codecov.io/gh/a-novel/service-json-keys/graphs/sunburst.svg)


### PR DESCRIPTION
## Summary

- Removes the post-merge `report-grc` job and the Go Report Card README badge.
- [Go Report Card was sunset](https://goreportcard.com/report/github.com/a-novel/service-authentication) in July 2026 — the job POSTed to a now-dead endpoint and the badge renders broken. `golangci-lint` (the `lint-go` check) remains the real static-analysis gate.

## Breaking changes

None.

## Test plan

- [ ] CI green