### PR TITLE
chore(ci): add the shared lint-dockerfile job

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -53,6 +53,14 @@ jobs:
           client_id: ${{ vars.DEPENDENCY_BOT_CLIENT_ID }}
           lint_action: "lint:ci"
 
+  lint-dockerfile:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+      - uses: a-novel-kit/workflows/generic-actions/lint-dockerfile@v1.25.0
+
   test-go:
     needs: [lint-go, build-database]
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- Adopts the shared **lint-dockerfile job** from `a-novel-kit/workflows` v1.25.0, pinned at the version every
  other `a-novel-kit/workflows` ref in this repo already uses.
- **No advisory phase.** All 7 Dockerfiles are already hadolint-clean (the repo tracks no `*.sh`, so lint-shell is not added) — so these gate from the first run rather than reporting into the void.

## Why now

The two actions landed in workflows v1.25.0 (a-novel-kit/workflows#373, #374) and the workflows repo
cleared its own backlog and flipped its `lint-shell` to gating in a-novel-kit/workflows#375. This is
the fleet rollout of the same lint.

hadolint also shellchecks each `RUN` block, so `lint-dockerfile` covers shell that `lint-shell`
(which lints tracked `*.sh` only) never sees.

## Follow-up for the merger

A new `main.yaml` job becomes a **required check** on the next `a-novel repo update` — until that
runs, the job executes but gates nothing. Reconcile after merge.

## Breaking changes

None. CI config only; no source or build file is touched.

## Test plan

- [x] The linter was run locally over this repo's `origin/master` at the pinned versions
      (shellcheck 0.10.0 / hadolint v2.12.0, matching the actions) — **0 findings**
- [x] `prettier --check .github/workflows/main.yaml` clean
- [ ] CI green