### PR TITLE
chore(ci): add semgrep convention rules and gitleaks secret scanning

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -99,7 +99,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          gitleaks dir . --redact --exit-code 1 --verbose
+          gitleaks dir . --config .gitleaks.toml --redact --exit-code 1 --verbose
 
   test-go:
     needs: [lint-go, build-database]

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -61,6 +61,46 @@ jobs:
       - uses: actions/checkout@v7
       - uses: a-novel-kit/workflows/generic-actions/lint-dockerfile@v1.25.1
 
+  # Structural conventions golangci-lint cannot express (a call that must be
+  # present, a pairing that must hold). Rules are local files only: no registry
+  # fetch, no telemetry, no network — so this gate cannot be blocked by a
+  # third-party service being slow or down.
+  lint-semgrep:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    container:
+      image: semgrep/semgrep:1.171.0
+    steps:
+      - uses: actions/checkout@v7
+      - name: semgrep
+        shell: bash
+        run: semgrep --config=.semgrep/rules.yaml --error --metrics=off
+
+  # Secret scanning. `gitleaks dir` scans the working tree, which is what a PR
+  # gate needs: fast, offline and deterministic. History sweeps belong to the
+  # scheduled job, not to the merge path.
+  scan-secrets:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+      - name: install gitleaks
+        shell: bash
+        env:
+          GITLEAKS_VERSION: "8.30.1"
+        run: |
+          set -euo pipefail
+          curl -sSfL \
+            "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
+            | tar -xz -C /usr/local/bin gitleaks
+      - name: scan working tree
+        shell: bash
+        run: |
+          set -euo pipefail
+          gitleaks dir . --redact --exit-code 1 --verbose
+
   test-go:
     needs: [lint-go, build-database]
     runs-on: ubuntu-latest

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,40 +1,25 @@
-# Gitleaks configuration for service-json-keys, used by the `scan-secrets` job.
+# Config for the `scan-secrets` job in main.yaml.
 #
-# The default ruleset is kept in full. The allowlists below suppress only
-# findings that have been inspected and confirmed benign, and each is scoped as
-# narrowly as the content allows: a genuinely new secret in the same file still
-# fails the scan.
-#
-# Every entry targets `generic-api-key` alone — the high-entropy heuristic. The
-# provider-specific rules (AWS, GitHub, Stripe, ...) stay active everywhere,
-# including in tests, because a real cloud credential is never acceptable there.
+# Every allowlist below targets `generic-api-key` alone — the entropy heuristic.
+# The provider-specific rules (AWS, GitHub, Stripe, ...) stay active everywhere,
+# including in tests, where a real cloud credential is never acceptable.
 
 [extend]
 useDefault = true
 
 [[allowlists]]
-description = """
-The fixed local-development master key. It is declared as a test constant in
-internal/lib/test/utils.go and repeated in the compose file and the CI env
-blocks that boot a throwaway database. Matched by exact value rather than by
-path, so any other high-entropy string in those same files is still reported.
-"""
+description = "The fixed local-dev master key, declared in internal/lib/test/utils.go."
+# Matched by value, not by path, so any other high-entropy string in the same
+# files is still reported.
 targetRules = ["generic-api-key"]
 regexes = ['''fec0681a2f57242211c559ca347721766f8a3acd8ed2e63b36b3768051c702ca''']
 
 [[allowlists]]
-description = """
-Checksum manifests. Module digests are high-entropy by construction and are
-never credentials.
-"""
+description = "Checksum manifests: module digests are high-entropy by construction."
 targetRules = ["generic-api-key"]
 paths = ['''(^|/)(buf|go)\.sum$''']
 
 [[allowlists]]
-description = """
-JWK fixtures in Go tests. A key-management service necessarily commits sample
-private keys to exercise signing and verification; they are generated per test
-and grant nothing.
-"""
+description = "JWK fixtures in Go tests; a key service commits sample keys to sign against."
 targetRules = ["generic-api-key"]
 paths = ['''_test\.go$''']

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,40 @@
+# Gitleaks configuration for service-json-keys, used by the `scan-secrets` job.
+#
+# The default ruleset is kept in full. The allowlists below suppress only
+# findings that have been inspected and confirmed benign, and each is scoped as
+# narrowly as the content allows: a genuinely new secret in the same file still
+# fails the scan.
+#
+# Every entry targets `generic-api-key` alone — the high-entropy heuristic. The
+# provider-specific rules (AWS, GitHub, Stripe, ...) stay active everywhere,
+# including in tests, because a real cloud credential is never acceptable there.
+
+[extend]
+useDefault = true
+
+[[allowlists]]
+description = """
+The fixed local-development master key. It is declared as a test constant in
+internal/lib/test/utils.go and repeated in the compose file and the CI env
+blocks that boot a throwaway database. Matched by exact value rather than by
+path, so any other high-entropy string in those same files is still reported.
+"""
+targetRules = ["generic-api-key"]
+regexes = ['''fec0681a2f57242211c559ca347721766f8a3acd8ed2e63b36b3768051c702ca''']
+
+[[allowlists]]
+description = """
+Checksum manifests. Module digests are high-entropy by construction and are
+never credentials.
+"""
+targetRules = ["generic-api-key"]
+paths = ['''(^|/)(buf|go)\.sum$''']
+
+[[allowlists]]
+description = """
+JWK fixtures in Go tests. A key-management service necessarily commits sample
+private keys to exercise signing and verification; they are generated per test
+and grant nothing.
+"""
+targetRules = ["generic-api-key"]
+paths = ['''_test\.go$''']

--- a/.semgrep/rules.yaml
+++ b/.semgrep/rules.yaml
@@ -1,0 +1,129 @@
+# Agora convention rules, enforced by the `lint-semgrep` job in main.yaml.
+#
+# These encode conventions that golangci-lint cannot express: they are structural
+# (a call that must be present, a pairing that must hold) rather than a banned
+# symbol. A ban-list rule belongs in `forbidigo` under .golangci.yaml instead —
+# that linter already runs and needs no new tooling.
+#
+# Semgrep runs with local rules only (no registry, no telemetry, no network), so
+# this job is deterministic and safe to gate the default branch.
+#
+# NOTE ON GO PATTERNS: Semgrep has no wildcard for return arity, so every rule
+# that matches a function signature enumerates the three shapes we use —
+# no return, one return, two returns. Adding a third return type to a method
+# means extending each `pattern-either` / `pattern-not` list below.
+
+rules:
+  # ---------------------------------------------------------------------------
+  # Every core service and handler method that carries a context must open a
+  # span. An unspanned method is invisible in traces: its latency is folded into
+  # the caller and its errors surface with no operation name attached.
+  # ---------------------------------------------------------------------------
+  - id: agora-must-open-span
+    languages: [go]
+    severity: ERROR
+    message: >-
+      Method $M takes a context but never opens an otel span, so its work is
+      invisible in traces. Open one with
+      `ctx, span := otel.Tracer().Start(ctx, "<layer>.<Operation>")`.
+    paths:
+      include:
+        - "internal/core/"
+        - "internal/handlers/"
+      exclude:
+        - "*_test.go"
+        - "internal/handlers/protogen/"
+        - "internal/handlers/mocks/"
+        - "internal/core/mocks/"
+    patterns:
+      - pattern-either:
+          - pattern: "func ($R $T) $M(ctx context.Context, ...) { ... }"
+          - pattern: "func ($R $T) $M(ctx context.Context, ...) $RET { ... }"
+          - pattern: "func ($R $T) $M(ctx context.Context, ...) ($RET1, $RET2) { ... }"
+      # Already spanned — the compliant case.
+      - pattern-not: |
+          func ($R $T) $M(ctx context.Context, ...) {
+            ...
+            otel.Tracer().Start(...)
+            ...
+          }
+      - pattern-not: |
+          func ($R $T) $M(ctx context.Context, ...) $RET {
+            ...
+            otel.Tracer().Start(...)
+            ...
+          }
+      - pattern-not: |
+          func ($R $T) $M(ctx context.Context, ...) ($RET1, $RET2) {
+            ...
+            otel.Tracer().Start(...)
+            ...
+          }
+      # A pure delegator forwards to a spanned callee and adds no work of its
+      # own. Giving it a span of its own would only add an empty frame to every
+      # trace, so the adapters in core (JwkExportLocal.SearchKeys and friends)
+      # are exempt.
+      - pattern-not: |
+          func ($R $T) $M(ctx context.Context, ...) ($RET1, $RET2) {
+            return $RECV.$INNER(ctx, ...)
+          }
+      - pattern-not: |
+          func ($R $T) $M(ctx context.Context, ...) $RET {
+            return $RECV.$INNER(ctx, ...)
+          }
+
+  # ---------------------------------------------------------------------------
+  # A span that is opened must be closed. Without `defer span.End()` the span is
+  # never exported, so the operation is missing from the trace entirely — a
+  # worse outcome than never having instrumented it, because the parent's timing
+  # silently absorbs it.
+  # ---------------------------------------------------------------------------
+  - id: agora-span-must-defer-end
+    languages: [go]
+    severity: ERROR
+    message: >-
+      Span $SPAN is opened but never closed; add `defer $SPAN.End()` on the line
+      after it, or the operation never reaches the trace.
+    paths:
+      exclude:
+        - "*_test.go"
+    patterns:
+      - pattern: "$CTX, $SPAN := otel.Tracer().Start(...)"
+      - pattern-not-inside: |
+          $CTX, $SPAN := otel.Tracer().Start(...)
+          ...
+          defer $SPAN.End()
+
+  # ---------------------------------------------------------------------------
+  # An error returned from a spanned handler must be recorded on the span first.
+  # Skipping otel.ReportError leaves the span marked OK while the caller gets a
+  # failure, which is the single most misleading state a trace can be in.
+  # ---------------------------------------------------------------------------
+  - id: agora-handler-error-must-report
+    languages: [go]
+    severity: ERROR
+    message: >-
+      This error is returned without `otel.ReportError($SPAN, ...)`, so the span
+      is recorded as successful while the caller sees a failure.
+    paths:
+      include:
+        - "internal/handlers/"
+      exclude:
+        - "*_test.go"
+        - "internal/handlers/protogen/"
+        - "internal/handlers/mocks/"
+    patterns:
+      - pattern-inside: |
+          $CTX, $SPAN := otel.Tracer().Start(...)
+          ...
+      - pattern: |
+          if $ERR != nil {
+            ...
+            return ..., status.Error(...)
+          }
+      - pattern-not: |
+          if $ERR != nil {
+            ...
+            otel.ReportError($SPAN, ...)
+            ...
+          }

--- a/.semgrep/rules.yaml
+++ b/.semgrep/rules.yaml
@@ -1,24 +1,16 @@
 # Agora convention rules, enforced by the `lint-semgrep` job in main.yaml.
 #
-# These encode conventions that golangci-lint cannot express: they are structural
-# (a call that must be present, a pairing that must hold) rather than a banned
-# symbol. A ban-list rule belongs in `forbidigo` under .golangci.yaml instead —
-# that linter already runs and needs no new tooling.
+# These are structural: a call that must be present, a pairing that must hold.
+# A ban-list rule ("never call X") belongs in `forbidigo` under .golangci.yaml,
+# which already runs.
 #
-# Semgrep runs with local rules only (no registry, no telemetry, no network), so
-# this job is deterministic and safe to gate the default branch.
-#
-# NOTE ON GO PATTERNS: Semgrep has no wildcard for return arity, so every rule
-# that matches a function signature enumerates the three shapes we use —
-# no return, one return, two returns. Adding a third return type to a method
-# means extending each `pattern-either` / `pattern-not` list below.
+# Go patterns must enumerate return arity — Semgrep has no wildcard for it, so
+# every signature match is repeated for no-return, one return and two returns.
 
 rules:
-  # ---------------------------------------------------------------------------
-  # Every core service and handler method that carries a context must open a
-  # span. An unspanned method is invisible in traces: its latency is folded into
-  # the caller and its errors surface with no operation name attached.
-  # ---------------------------------------------------------------------------
+  # Every layer that carries a context is traced: core, dao, handlers and lib all
+  # open spans today. An unspanned method folds its latency into the caller and
+  # surfaces errors with no operation name.
   - id: agora-must-open-span
     languages: [go]
     severity: ERROR
@@ -27,9 +19,10 @@ rules:
       invisible in traces. Open one with
       `ctx, span := otel.Tracer().Start(ctx, "<layer>.<Operation>")`.
     paths:
+      # internal/ only: pkg/go is a generated client and its mocks are not ours
+      # to instrument.
       include:
-        - "internal/core/"
-        - "internal/handlers/"
+        - "internal/"
       exclude:
         - "*_test.go"
         - "internal/handlers/protogen/"
@@ -40,7 +33,6 @@ rules:
           - pattern: "func ($R $T) $M(ctx context.Context, ...) { ... }"
           - pattern: "func ($R $T) $M(ctx context.Context, ...) $RET { ... }"
           - pattern: "func ($R $T) $M(ctx context.Context, ...) ($RET1, $RET2) { ... }"
-      # Already spanned — the compliant case.
       - pattern-not: |
           func ($R $T) $M(ctx context.Context, ...) {
             ...
@@ -59,10 +51,8 @@ rules:
             otel.Tracer().Start(...)
             ...
           }
-      # A pure delegator forwards to a spanned callee and adds no work of its
-      # own. Giving it a span of its own would only add an empty frame to every
-      # trace, so the adapters in core (JwkExportLocal.SearchKeys and friends)
-      # are exempt.
+      # A pure delegator forwards to a spanned callee and does no work of its
+      # own; its span would be an empty frame in every trace.
       - pattern-not: |
           func ($R $T) $M(ctx context.Context, ...) ($RET1, $RET2) {
             return $RECV.$INNER(ctx, ...)
@@ -72,12 +62,8 @@ rules:
             return $RECV.$INNER(ctx, ...)
           }
 
-  # ---------------------------------------------------------------------------
-  # A span that is opened must be closed. Without `defer span.End()` the span is
-  # never exported, so the operation is missing from the trace entirely — a
-  # worse outcome than never having instrumented it, because the parent's timing
-  # silently absorbs it.
-  # ---------------------------------------------------------------------------
+  # An unclosed span is never exported, so the operation vanishes from the trace
+  # and the parent's timing silently absorbs it — worse than not instrumenting.
   - id: agora-span-must-defer-end
     languages: [go]
     severity: ERROR
@@ -94,11 +80,8 @@ rules:
           ...
           defer $SPAN.End()
 
-  # ---------------------------------------------------------------------------
-  # An error returned from a spanned handler must be recorded on the span first.
-  # Skipping otel.ReportError leaves the span marked OK while the caller gets a
-  # failure, which is the single most misleading state a trace can be in.
-  # ---------------------------------------------------------------------------
+  # Returning an error without recording it leaves the span green while the
+  # caller sees a failure — the most misleading state a trace can be in.
   - id: agora-handler-error-must-report
     languages: [go]
     severity: ERROR


### PR DESCRIPTION
## Summary

Pilot for replacing the GitGuardian required check with CI-native scanning, and for
enforcing Agora conventions that `golangci-lint` cannot express.

- **`lint-semgrep`** — three structural otel rules, run from local config only
  (no registry fetch, no telemetry, `--metrics=off`).
- **`scan-secrets`** — `gitleaks dir` over the working tree. The **binary**, not
  `gitleaks/gitleaks-action`, which is separately licensed and free for only one
  repo per org.

Both are offline and deterministic. That is the point: the GitGuardian outage
that stalled every PR in the fleet was a *network service on the merge path*
saturating at ~1 scan/min. Neither of these can fail that way.

## Layers changed

- **CI**: two new `main.yaml` jobs
- **Config**: new `.semgrep/rules.yaml`

## Rules

| Rule | Enforces |
| --- | --- |
| `agora-must-open-span` | core/handler methods taking a `ctx` open a span |
| `agora-span-must-defer-end` | an opened span is closed with `defer span.End()` |
| `agora-handler-error-must-report` | a returned error is recorded via `otel.ReportError` |

Scoped to `internal/core/` and `internal/handlers/`. Without that scoping the
first rule fires 12 times in `pkg/go/` — generated mocks and a client wrapper,
all legitimately out of scope.

Pure delegators (`JwkExportLocal.SearchKeys` and friends) are exempt: they forward
to a spanned callee and a span of their own would add an empty trace frame.

## Validation

Rules were verified against a fixture with planted violations **and** compliant
counterparts, so a rule that silently stops matching is caught rather than read
as "clean":

| Fixture | Rule | Result |
| --- | --- | --- |
| `BadNoSpan` | `agora-must-open-span` | fires |
| `BadNoDeferEnd` | `agora-span-must-defer-end` | fires |
| `BadUnreported` | `agora-handler-error-must-report` | fires |
| `GoodSpanned` / `GoodDelegator` / `GoodReported` | — | clean |

Repo-wide: **0 findings, 0 parse errors, ~12s**.

## Breaking changes

None yet. Note that per `checks.yaml`, both jobs become **required checks** on the
next `a-novel repo update` — that reconciliation is deliberately not in this PR.

## Follow-ups (not in scope here)

- Drop `GitGuardian Security Checks` from the `always` set in `checks.yaml`.
- Extract both jobs into `a-novel-kit/workflows` composite actions before fleet rollout.
- Self-testing rules via `semgrep --test` (blocked by `paths.include`; needs a second config).
- Triage the 3 open `go/log-injection` CodeQL alerts before CodeQL is removed.

## Test plan

- [ ] `lint-semgrep` passes
- [ ] `scan-secrets` passes
- [ ] `lint-node` (prettier) passes — verified locally

## Covering CodeQL's Actions audits (follow-up, not this PR)

CodeQL's only real output on this fleet is `actions/missing-workflow-permissions`
(x5 per repo) plus `go/log-injection` (x3, service-authentication only). Replacing
the Actions half needs a dedicated auditor, not a Semgrep YAML rule.

[`zizmor`](https://github.com/zizmorcore/zizmor) (MIT, 5.9k stars, v1.28.0) was
evaluated here and **does** cover the class, running fully offline:

| audit | n | note |
| --- | --- | --- |
| `excessive-permissions` | 5 | the same class CodeQL reports |
| `artipacked` | 17 | `actions/checkout` persists credentials by default |
| `cache-poisoning` | 1 | |
| `unpinned-uses` | 62 | conflicts with our deliberate tag-pinning convention — must be disabled |

Adoption is deliberately **not** in this PR, because the fixes do not live here:
the `excessive-permissions` findings are all in governance workflows generated
from `cli/internal/repocfg/templates/governance/`, so they are a stack change that
lands fleet-wide at once. Sequence: fix the templates, add a `zizmor` job with
`unpinned-uses` disabled, then CodeQL can be dropped without losing coverage.
