### PR TITLE
ci(ci): cut cost-only job edges from the main graph

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -7,6 +7,12 @@ on:
     branches:
       - "**"
 
+# A `needs:` edge here means the downstream job cannot run without something the upstream one
+# produces — an image digest, a coverage artifact ID, a file on disk. Edges that only expressed
+# "don't spend a runner if the previous check failed" are gone: the jobs sit on separate runners
+# with separate checkouts, so an upstream verdict never changes a downstream one, and each such
+# edge cost the entire graph one job's latency. merge-gate still holds the merge itself, so a red
+# check blocks the PR whether or not the rest of the graph ran.
 jobs:
   generated-go:
     runs-on: ubuntu-latest
@@ -28,7 +34,6 @@ jobs:
 
   lint-go:
     runs-on: ubuntu-latest
-    needs: [generated-go]
     permissions:
       contents: read
     steps:
@@ -117,7 +122,10 @@ jobs:
           version: "1.28.0"
 
   test-go:
-    needs: [lint-go, build-database]
+    # build-database only: it hands over the image digest below. lint-go is not a dependency —
+    # it runs on its own runner against its own checkout, so its verdict cannot change this
+    # job's, and waiting on it only pushed the whole graph back by a lint run.
+    needs: [build-database]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -140,7 +148,6 @@ jobs:
           --health-timeout 5s
           --health-retries 5
     env:
-      POSTGRES_DSN_TEST: postgres://postgres:postgres@localhost:5432/postgres?sslmode=disable
       POSTGRES_DSN: postgres://postgres:postgres@localhost:5432/postgres?sslmode=disable
       APP_MASTER_KEY: "fec0681a2f57242211c559ca347721766f8a3acd8ed2e63b36b3768051c702ca"
     steps:
@@ -331,7 +338,7 @@ jobs:
           run_args: -e POSTGRES_DSN="${POSTGRES_DSN}"
 
   build-rotate-keys:
-    needs: [test-go, build-database]
+    needs: [build-database]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -370,7 +377,7 @@ jobs:
           run_args: -e POSTGRES_DSN="${POSTGRES_DSN}" -e APP_MASTER_KEY="${APP_MASTER_KEY}"
 
   build-grpc:
-    needs: [test-go, build-database]
+    needs: [build-database]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -409,7 +416,6 @@ jobs:
           run_args: -e POSTGRES_DSN="${POSTGRES_DSN}" -e APP_MASTER_KEY="${APP_MASTER_KEY}"
 
   build-standalone-grpc:
-    needs: [test-go]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -430,7 +436,7 @@ jobs:
           skip_healthcheck: true
 
   build-rest:
-    needs: [test-go, build-database]
+    needs: [build-database]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -469,7 +475,6 @@ jobs:
           run_args: -e POSTGRES_DSN="${POSTGRES_DSN}" -e APP_MASTER_KEY="${APP_MASTER_KEY}"
 
   build-standalone-rest:
-    needs: [test-go]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -490,7 +495,6 @@ jobs:
           skip_healthcheck: true
 
   build-js:
-    needs: [test-pkg-js]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -518,7 +522,11 @@ jobs:
   publish-docs:
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/master' && success()
-    needs: [build-js]
+    # This job deploys two committed files, openapi.html and openapi.yaml, and builds nothing.
+    # lint-node is the gate that matches: its `lint:ci` runs redocly over openapi.yaml and
+    # prettier over both. It used to hang off build-js, which compiles the TypeScript client and
+    # never reads either file — a chain through test-pkg-js and the whole Go lane for no signal.
+    needs: [lint-node]
     # GitHub Pages allows one deployment in flight per site. The group serializes concurrent
     # master runs.
     concurrency:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -7,12 +7,6 @@ on:
     branches:
       - "**"
 
-# A `needs:` edge here means the downstream job cannot run without something the upstream one
-# produces — an image digest, a coverage artifact ID, a file on disk. Edges that only expressed
-# "don't spend a runner if the previous check failed" are gone: the jobs sit on separate runners
-# with separate checkouts, so an upstream verdict never changes a downstream one, and each such
-# edge cost the entire graph one job's latency. merge-gate still holds the merge itself, so a red
-# check blocks the PR whether or not the rest of the graph ran.
 jobs:
   generated-go:
     runs-on: ubuntu-latest
@@ -122,9 +116,6 @@ jobs:
           version: "1.28.0"
 
   test-go:
-    # build-database only: it hands over the image digest below. lint-go is not a dependency —
-    # it runs on its own runner against its own checkout, so its verdict cannot change this
-    # job's, and waiting on it only pushed the whole graph back by a lint run.
     needs: [build-database]
     runs-on: ubuntu-latest
     permissions:
@@ -522,10 +513,7 @@ jobs:
   publish-docs:
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/master' && success()
-    # This job deploys two committed files, openapi.html and openapi.yaml, and builds nothing.
-    # lint-node is the gate that matches: its `lint:ci` runs redocly over openapi.yaml and
-    # prettier over both. It used to hang off build-js, which compiles the TypeScript client and
-    # never reads either file — a chain through test-pkg-js and the whole Go lane for no signal.
+    # lint-node is what checks the openapi files this deploys.
     needs: [lint-node]
     # GitHub Pages allows one deployment in flight per site. The group serializes concurrent
     # master runs.


### PR DESCRIPTION
## Summary

Fleet-wide sweep over `main.yaml`. A `needs:` edge now exists only where the downstream job
consumes something the upstream one produces — an image digest, a coverage artifact ID, a file on
disk. Edges that only meant *don't spend a runner if the previous check failed* are gone: those jobs
run on separate runners against separate checkouts, so an upstream verdict never changed a
downstream one, and each such edge cost the whole graph one job's latency.

Also in this repo:

- **Dropped a dead env var.** `test-go` declared `POSTGRES_DSN_TEST`, which nothing in the
  repository — or anywhere in the fleet — reads. It duplicated `POSTGRES_DSN`.
- **`publish-docs` now hangs off `lint-node`, not `build-js`.** It deploys two committed files,
  `openapi.html` and `openapi.yaml`, and builds nothing. `lint-node` is the job that actually
  validates them (`lint:ci` → `lint:js` → `redocly lint openapi.yaml`, plus `prettier --check` over
  both). `build-js` compiles the TypeScript client and reads neither file, so the old edge dragged
  the docs deploy through the entire Go lane for no signal.

## Effect

Critical path, simulated against the per-job durations of this repo's last green `master` run:

| | before | after |
| --- | --- | --- |
| whole run | 5.8 min | **2.5 min** |
| time to all required checks (i.e. mergeable) | 5.6 min | **2.3 min** (−59%) |

The run is now bounded by `build-grpc`; it used to be bounded by the `generated-go → lint-go →
test-go → build-standalone-rest → test-pkg-js → build-js → publish-docs` chain.

A red check still blocks the merge — `merge-gate` holds that, not the graph shape. What changed is
that a failing lint no longer withholds the test result, so a run reports every failure it has in
one pass instead of one layer at a time.

## Required checks

No job was added, renamed or removed. The set of job IDs `main.yaml` declares is identical to
`master`'s, so the derived required-check list is unchanged and **no `a-novel repo update` is
needed**.

## Test plan

- [x] every file parses; no cycles; every `needs:` names a declared job
- [x] every `needs.X` expression names a job that is actually in that job's `needs` list
- [x] `prettier --check` clean
- [x] `zizmor` 1.28.0 clean, run offline with the fleet baseline config
- [ ] CI green on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)