### PR TITLE
feat(migrations): verify reversible migration history

### DIFF
--- a/.github/workflows/approve-pr.yaml
+++ b/.github/workflows/approve-pr.yaml
@@ -25,7 +25,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: a-novel-kit/workflows/generic-actions/approve-pr@v1.26.2
+      - uses: a-novel-kit/workflows/generic-actions/approve-pr@v1.27.1
         with:
           pull_request: ${{ inputs.pull_request }}
           client_id: ${{ vars.AGENT_BOT_CLIENT_ID }}

--- a/.github/workflows/auto-approve-dependabot.yaml
+++ b/.github/workflows/auto-approve-dependabot.yaml
@@ -20,7 +20,7 @@ jobs:
     # the callee mints a scoped App token and declares permissions: {}; the caller sets the ceiling, so it must not hand down
     # the repository default.
     permissions: {}
-    uses: a-novel-kit/workflows/.github/workflows/auto-approve-dependabot-run.yaml@v1.26.2
+    uses: a-novel-kit/workflows/.github/workflows/auto-approve-dependabot-run.yaml@v1.27.1
     with:
       client_id: ${{ vars.AGENT_BOT_CLIENT_ID }}
       dependency_bot_login: ${{ vars.DEPENDENCY_BOT_LOGIN }}

--- a/.github/workflows/auto-assign-author.yaml
+++ b/.github/workflows/auto-assign-author.yaml
@@ -10,6 +10,6 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: a-novel-kit/workflows/generic-actions/assign-bot@v1.26.2
+      - uses: a-novel-kit/workflows/generic-actions/assign-bot@v1.27.1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/derive-status.yaml
+++ b/.github/workflows/derive-status.yaml
@@ -25,7 +25,7 @@ jobs:
       pull-requests: read
       issues: read
     steps:
-      - uses: a-novel-kit/workflows/generic-actions/derive-status@v1.26.2
+      - uses: a-novel-kit/workflows/generic-actions/derive-status@v1.27.1
         with:
           client_id: ${{ vars.AGENT_BOT_CLIENT_ID }}
           app_private_key: ${{ secrets.AGENT_BOT_PRIVATE_KEY }}

--- a/.github/workflows/epic-freeze.yaml
+++ b/.github/workflows/epic-freeze.yaml
@@ -33,7 +33,7 @@ jobs:
     # a stray forward is sweep-only, so a per-PR run can never re-enqueue.
     permissions: {}
     steps:
-      - uses: a-novel-kit/workflows/generic-actions/detect-partial-landing@v1.26.2
+      - uses: a-novel-kit/workflows/generic-actions/detect-partial-landing@v1.27.1
         with:
           client_id: ${{ vars.AGENT_BOT_CLIENT_ID }}
           app_private_key: ${{ secrets.AGENT_BOT_PRIVATE_KEY }}

--- a/.github/workflows/epic-rollback.yaml
+++ b/.github/workflows/epic-rollback.yaml
@@ -52,7 +52,7 @@ jobs:
     # the repository default.
     permissions:
       contents: read
-    uses: a-novel-kit/workflows/.github/workflows/epic-rollback-run.yaml@v1.26.2
+    uses: a-novel-kit/workflows/.github/workflows/epic-rollback-run.yaml@v1.27.1
     with:
       epic_number: ${{ inputs.epic_number }}
       confirm: ${{ inputs.confirm }}

--- a/.github/workflows/hotfix.yaml
+++ b/.github/workflows/hotfix.yaml
@@ -51,7 +51,7 @@ jobs:
     permissions:
       contents: write
       actions: read
-    uses: a-novel-kit/workflows/.github/workflows/hotfix-run.yaml@v1.26.2
+    uses: a-novel-kit/workflows/.github/workflows/hotfix-run.yaml@v1.27.1
     with:
       line: ${{ inputs.line }}
       fix_ref: ${{ inputs.fix_ref }}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -5,13 +5,50 @@ on:
     tags-ignore:
       - "**"
     branches:
-      - "**"
+      - master
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+  merge_group:
 
 jobs:
-  generated-go:
+  check-migration-snapshots:
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: a-novel-kit/workflows/generic-actions/check-append-only@v1.27.1
+        with:
+          path: internal/models/migrations/testdata/schema
+          base: ${{ github.event.pull_request.base.sha }}
+
+  generated-go:
+    needs: [build-database]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    services:
+      postgres:
+        image: ghcr.io/a-novel/service-json-keys/database@${{ needs.build-database.outputs.digest }}
+        ports:
+          - "5432:5432"
+        env:
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_USER: postgres
+          POSTGRES_DB: postgres
+          POSTGRES_HOST_AUTH_METHOD: scram-sha-256
+          POSTGRES_INITDB_ARGS: --auth=scram-sha-256
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      POSTGRES_DSN: postgres://postgres:postgres@localhost:5432/postgres?sslmode=disable
     steps:
       - uses: actions/checkout@v7
         with:
@@ -22,7 +59,7 @@ jobs:
       - name: go generate
         shell: bash
         run: go generate ./...
-      - uses: a-novel-kit/workflows/generic-actions/check-changes@v1.26.2
+      - uses: a-novel-kit/workflows/generic-actions/check-changes@v1.27.1
         with:
           fail_message: go generate definitions are not up-to-date, please run 'go generate ./...' and commit the changes
 
@@ -31,7 +68,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: a-novel-kit/workflows/go-actions/lint-go@v1.26.2
+      - uses: a-novel-kit/workflows/go-actions/lint-go@v1.27.1
 
   lint-proto:
     runs-on: ubuntu-latest
@@ -42,6 +79,8 @@ jobs:
         with:
           persist-credentials: false
       - uses: bufbuild/buf-action@v1
+        with:
+          pr_comment: false
 
   lint-node:
     runs-on: ubuntu-latest
@@ -49,7 +88,7 @@ jobs:
       contents: read
       packages: read
     steps:
-      - uses: a-novel-kit/workflows/node-actions/lint-node@v1.26.2
+      - uses: a-novel-kit/workflows/node-actions/lint-node@v1.27.1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           app_private_key: ${{ secrets.DEPENDENCY_BOT_PRIVATE_KEY }}
@@ -64,7 +103,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           persist-credentials: false
-      - uses: a-novel-kit/workflows/generic-actions/lint-dockerfile@v1.26.2
+      - uses: a-novel-kit/workflows/generic-actions/lint-dockerfile@v1.27.1
         with:
           # renovate: datasource=github-releases depName=hadolint/hadolint
           version: "2.14.0"
@@ -78,7 +117,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           persist-credentials: false
-      - uses: a-novel-kit/workflows/security-actions/lint-semgrep@v1.26.2
+      - uses: a-novel-kit/workflows/security-actions/lint-semgrep@v1.27.1
         with:
           ruleset: service
           # renovate: datasource=docker depName=semgrep/semgrep
@@ -94,7 +133,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           persist-credentials: false
-      - uses: a-novel-kit/workflows/security-actions/scan-secrets@v1.26.2
+      - uses: a-novel-kit/workflows/security-actions/scan-secrets@v1.27.1
         with:
           config: .gitleaks.toml
           # renovate: datasource=github-releases depName=gitleaks/gitleaks
@@ -110,7 +149,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           persist-credentials: false
-      - uses: a-novel-kit/workflows/security-actions/lint-workflows@v1.26.2
+      - uses: a-novel-kit/workflows/security-actions/lint-workflows@v1.27.1
         with:
           # renovate: datasource=docker depName=ghcr.io/zizmorcore/zizmor
           version: "1.28.0"
@@ -157,7 +196,7 @@ jobs:
         run: |
           go run ./cmd/rotate-keys
           go run ./cmd/rotate-keys
-      - uses: a-novel-kit/workflows/go-actions/test-go@v1.26.2
+      - uses: a-novel-kit/workflows/go-actions/test-go@v1.27.1
         id: test
         with:
           filter_extra_patterns: "| grep /internal | grep -v /protogen"
@@ -207,7 +246,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           persist-credentials: false
-      - uses: a-novel-kit/workflows/go-actions/test-go@v1.26.2
+      - uses: a-novel-kit/workflows/go-actions/test-go@v1.27.1
         id: test
         with:
           filter_extra_patterns: "| grep /pkg"
@@ -255,7 +294,7 @@ jobs:
     env:
       REST_URL: "http://localhost:8080"
     steps:
-      - uses: a-novel-kit/workflows/node-actions/test-node@v1.26.2
+      - uses: a-novel-kit/workflows/node-actions/test-node@v1.27.1
         id: test
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -280,7 +319,7 @@ jobs:
       POSTGRES_HOST_AUTH_METHOD: scram-sha-256
       POSTGRES_INITDB_ARGS: --auth=scram-sha-256
     steps:
-      - uses: a-novel-kit/workflows/build-actions/docker@v1.26.2
+      - uses: a-novel-kit/workflows/build-actions/docker@v1.27.1
         id: build
         with:
           file: builds/database.Dockerfile
@@ -321,7 +360,7 @@ jobs:
     env:
       POSTGRES_DSN: postgres://postgres:postgres@localhost:5432/postgres?sslmode=disable
     steps:
-      - uses: a-novel-kit/workflows/build-actions/docker-job@v1.26.2
+      - uses: a-novel-kit/workflows/build-actions/docker-job@v1.27.1
         with:
           file: builds/migrations.Dockerfile
           image_name: ${{ github.repository }}/jobs/migrations
@@ -360,7 +399,7 @@ jobs:
         with:
           persist-credentials: false
       - uses: ./.github/actions/run-migrations
-      - uses: a-novel-kit/workflows/build-actions/docker-job@v1.26.2
+      - uses: a-novel-kit/workflows/build-actions/docker-job@v1.27.1
         with:
           file: builds/rotate-keys.Dockerfile
           image_name: ${{ github.repository }}/jobs/rotatekeys
@@ -399,7 +438,7 @@ jobs:
         with:
           persist-credentials: false
       - uses: ./.github/actions/run-migrations
-      - uses: a-novel-kit/workflows/build-actions/docker@v1.26.2
+      - uses: a-novel-kit/workflows/build-actions/docker@v1.27.1
         with:
           file: builds/grpc.Dockerfile
           image_name: ${{ github.repository }}/grpc
@@ -418,7 +457,7 @@ jobs:
     # test-pkg boots and exercises this image in a full integration run, so this job only
     # builds and pushes it; skip_healthcheck drops the redundant smoke run.
     steps:
-      - uses: a-novel-kit/workflows/build-actions/docker@v1.26.2
+      - uses: a-novel-kit/workflows/build-actions/docker@v1.27.1
         id: build
         with:
           file: builds/standalone.grpc.Dockerfile
@@ -458,7 +497,7 @@ jobs:
         with:
           persist-credentials: false
       - uses: ./.github/actions/run-migrations
-      - uses: a-novel-kit/workflows/build-actions/docker@v1.26.2
+      - uses: a-novel-kit/workflows/build-actions/docker@v1.27.1
         with:
           file: builds/rest.Dockerfile
           image_name: ${{ github.repository }}/rest
@@ -477,7 +516,7 @@ jobs:
     # test-pkg-js boots and exercises this image in a full integration run, so this job only
     # builds and pushes it; skip_healthcheck drops the redundant smoke run.
     steps:
-      - uses: a-novel-kit/workflows/build-actions/docker@v1.26.2
+      - uses: a-novel-kit/workflows/build-actions/docker@v1.27.1
         id: build
         with:
           file: builds/standalone.rest.Dockerfile
@@ -491,7 +530,7 @@ jobs:
       contents: read
       packages: read
     steps:
-      - uses: a-novel-kit/workflows/node-actions/build-node@v1.26.2
+      - uses: a-novel-kit/workflows/node-actions/build-node@v1.27.1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           app_private_key: ${{ secrets.DEPENDENCY_BOT_PRIVATE_KEY }}
@@ -504,7 +543,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: a-novel-kit/workflows/generic-actions/codecov@v1.26.2
+      - uses: a-novel-kit/workflows/generic-actions/codecov@v1.27.1
         with:
           codecov_token: ${{ secrets.CODECOV_TOKEN }}
           coverage_files: coverage.txt,coverage_pkg.txt,coverage/*

--- a/.github/workflows/merge-gate.yaml
+++ b/.github/workflows/merge-gate.yaml
@@ -34,7 +34,7 @@ jobs:
     # the callee mints its own App token and declares permissions: {}; the caller sets the ceiling, so it must not hand down
     # the repository default.
     permissions: {}
-    uses: a-novel-kit/workflows/.github/workflows/merge-gate-run.yaml@v1.26.2
+    uses: a-novel-kit/workflows/.github/workflows/merge-gate-run.yaml@v1.27.1
     with:
       client_id: ${{ vars.AGENT_BOT_CLIENT_ID }}
       kill_switch: ${{ vars.AGENT_KILL_SWITCH }}

--- a/.github/workflows/node-audit.yaml
+++ b/.github/workflows/node-audit.yaml
@@ -11,7 +11,7 @@ jobs:
       contents: write
       packages: read
     steps:
-      - uses: a-novel-kit/workflows/node-actions/audit@v1.26.2
+      - uses: a-novel-kit/workflows/node-actions/audit@v1.27.1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           app_private_key: ${{ secrets.PUBLISH_BOT_PRIVATE_KEY }}

--- a/.github/workflows/release-train.yaml
+++ b/.github/workflows/release-train.yaml
@@ -39,7 +39,7 @@ jobs:
     # the repository default.
     permissions:
       contents: read
-    uses: a-novel-kit/workflows/.github/workflows/release-train-run.yaml@v1.26.2
+    uses: a-novel-kit/workflows/.github/workflows/release-train-run.yaml@v1.27.1
     with:
       client_id: ${{ vars.AGENT_BOT_CLIENT_ID }}
       epic_number: ${{ inputs.epic_number }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -47,7 +47,7 @@ jobs:
       tag: ${{ steps.core.outputs.tag }}
     steps:
       - id: core
-        uses: a-novel-kit/workflows/publish-actions/release-core@v1.26.2
+        uses: a-novel-kit/workflows/publish-actions/release-core@v1.27.1
         with:
           # renovate: datasource=go depName=github.com/a-novel-kit/stack/cli
           cli_version: "1.7.5"
@@ -72,7 +72,7 @@ jobs:
       POSTGRES_HOST_AUTH_METHOD: scram-sha-256
       POSTGRES_INITDB_ARGS: --auth=scram-sha-256
     steps:
-      - uses: a-novel-kit/workflows/build-actions/docker@v1.26.2
+      - uses: a-novel-kit/workflows/build-actions/docker@v1.27.1
         with:
           file: builds/database.Dockerfile
           image_name: ${{ github.repository }}/database
@@ -114,7 +114,7 @@ jobs:
     env:
       POSTGRES_DSN: postgres://postgres:postgres@localhost:5432/postgres?sslmode=disable
     steps:
-      - uses: a-novel-kit/workflows/build-actions/docker-job@v1.26.2
+      - uses: a-novel-kit/workflows/build-actions/docker-job@v1.27.1
         with:
           file: builds/migrations.Dockerfile
           image_name: ${{ github.repository }}/jobs/migrations
@@ -155,7 +155,7 @@ jobs:
         with:
           persist-credentials: false
       - uses: ./.github/actions/run-migrations
-      - uses: a-novel-kit/workflows/build-actions/docker-job@v1.26.2
+      - uses: a-novel-kit/workflows/build-actions/docker-job@v1.27.1
         with:
           file: builds/rotate-keys.Dockerfile
           image_name: ${{ github.repository }}/jobs/rotatekeys
@@ -196,7 +196,7 @@ jobs:
         with:
           persist-credentials: false
       - uses: ./.github/actions/run-migrations
-      - uses: a-novel-kit/workflows/build-actions/docker@v1.26.2
+      - uses: a-novel-kit/workflows/build-actions/docker@v1.27.1
         with:
           file: builds/grpc.Dockerfile
           image_name: ${{ github.repository }}/grpc
@@ -237,7 +237,7 @@ jobs:
         with:
           persist-credentials: false
       - uses: ./.github/actions/run-migrations
-      - uses: a-novel-kit/workflows/build-actions/docker@v1.26.2
+      - uses: a-novel-kit/workflows/build-actions/docker@v1.27.1
         with:
           file: builds/standalone.grpc.Dockerfile
           image_name: ${{ github.repository }}/standalone-grpc
@@ -278,7 +278,7 @@ jobs:
         with:
           persist-credentials: false
       - uses: ./.github/actions/run-migrations
-      - uses: a-novel-kit/workflows/build-actions/docker@v1.26.2
+      - uses: a-novel-kit/workflows/build-actions/docker@v1.27.1
         with:
           file: builds/rest.Dockerfile
           image_name: ${{ github.repository }}/rest
@@ -319,7 +319,7 @@ jobs:
         with:
           persist-credentials: false
       - uses: ./.github/actions/run-migrations
-      - uses: a-novel-kit/workflows/build-actions/docker@v1.26.2
+      - uses: a-novel-kit/workflows/build-actions/docker@v1.27.1
         with:
           file: builds/standalone.rest.Dockerfile
           image_name: ${{ github.repository }}/standalone-rest
@@ -336,7 +336,7 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: a-novel-kit/workflows/publish-actions/npm@v1.26.2
+      - uses: a-novel-kit/workflows/publish-actions/npm@v1.27.1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           app_private_key: ${{ secrets.PUBLISH_BOT_PRIVATE_KEY }}
@@ -360,7 +360,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: a-novel-kit/workflows/generic-actions/archive-board-items@v1.26.2
+      - uses: a-novel-kit/workflows/generic-actions/archive-board-items@v1.27.1
         with:
           client_id: ${{ vars.AGENT_BOT_CLIENT_ID }}
           app_private_key: ${{ secrets.AGENT_BOT_PRIVATE_KEY }}

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -18,7 +18,7 @@ jobs:
       id-token: write
       security-events: read
     steps:
-      - uses: a-novel-kit/workflows/generic-actions/renovate@v1.26.2
+      - uses: a-novel-kit/workflows/generic-actions/renovate@v1.27.1
         with:
           allowed_commands: |
             [

--- a/internal/models/migrations/migrations.go
+++ b/internal/models/migrations/migrations.go
@@ -4,6 +4,7 @@ import (
 	"embed"
 )
 
+//go:generate env GOLIB_UPDATE_SNAPSHOTS=1 go test -run ^TestMigrationRoundtrip$
 //go:embed *.sql
 
 // Migrations embeds all SQL migration files in the package directory.

--- a/internal/models/migrations/migrations_test.go
+++ b/internal/models/migrations/migrations_test.go
@@ -1,0 +1,27 @@
+package migrations_test
+
+import (
+	"io/fs"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/a-novel-kit/golib/postgres"
+
+	"github.com/a-novel/service-json-keys/v2/internal/config/configtest"
+	"github.com/a-novel/service-json-keys/v2/internal/models/migrations"
+)
+
+func TestMigrationRoundtrip(t *testing.T) {
+	t.Parallel()
+
+	_, err := fs.Stat(migrations.Migrations, "testdata")
+	require.ErrorIs(t, err, fs.ErrNotExist)
+
+	postgres.RunMigrationRoundtripTest(t, configtest.PostgresPreset, migrations.Migrations,
+		&postgres.RoundtripOptions{
+			Fixtures:  os.DirFS("testdata/fixtures"),
+			Snapshots: "testdata/schema",
+		})
+}

--- a/internal/models/migrations/testdata/fixtures/20260722072945_initial_schema.sql
+++ b/internal/models/migrations/testdata/fixtures/20260722072945_initial_schema.sql
@@ -1,0 +1,43 @@
+-- Rows span every active_keys predicate outcome.
+INSERT INTO
+  keys (
+    id,
+    private_key,
+    public_key,
+    usage,
+    created_at,
+    expires_at,
+    deleted_at,
+    deleted_comment
+  )
+VALUES
+  (
+    '00000000-0000-0000-0000-000000000001',
+    'fixture-private-active',
+    NULL,
+    'roundtrip',
+    '2026-07-22T07:29:45Z',
+    '2099-01-01T00:00:00Z',
+    NULL,
+    NULL
+  ),
+  (
+    '00000000-0000-0000-0000-000000000002',
+    'fixture-private-expired',
+    NULL,
+    'roundtrip',
+    '2020-01-01T00:00:00Z',
+    '2021-01-01T00:00:00Z',
+    NULL,
+    NULL
+  ),
+  (
+    '00000000-0000-0000-0000-000000000003',
+    'fixture-private-revoked',
+    NULL,
+    'roundtrip',
+    '2026-07-22T07:29:45Z',
+    '2099-01-01T00:00:00Z',
+    '2026-07-23T07:29:45Z',
+    'fixture revocation'
+  );

--- a/internal/models/migrations/testdata/schema/20260722072945_initial_schema.txt
+++ b/internal/models/migrations/testdata/schema/20260722072945_initial_schema.txt
@@ -1,0 +1,30 @@
+column	active_keys.created_at	timestamp(0) with time zone
+column	active_keys.deleted_at	timestamp(0) with time zone
+column	active_keys.deleted_comment	text
+column	active_keys.expires_at	timestamp(0) with time zone
+column	active_keys.id	uuid
+column	active_keys.private_key	text
+column	active_keys.public_key	text
+column	active_keys.usage	text
+column	keys.created_at	timestamp(0) with time zone NOT NULL
+column	keys.deleted_at	timestamp(0) with time zone
+column	keys.deleted_comment	text
+column	keys.expires_at	timestamp(0) with time zone NOT NULL
+column	keys.id	uuid NOT NULL
+column	keys.private_key	text NOT NULL
+column	keys.public_key	text
+column	keys.usage	text NOT NULL
+comment	schema public	standard public schema
+constraint	keys.keys_created_at_not_null	NOT NULL created_at
+constraint	keys.keys_expires_at_not_null	NOT NULL expires_at
+constraint	keys.keys_id_not_null	NOT NULL id
+constraint	keys.keys_pkey	PRIMARY KEY (id)
+constraint	keys.keys_private_key_check	CHECK ((private_key <> ''::text))
+constraint	keys.keys_private_key_not_null	NOT NULL private_key
+constraint	keys.keys_usage_not_null	NOT NULL usage
+extension	plpgsql	1.0
+index	keys_pkey	CREATE UNIQUE INDEX keys_pkey ON public.keys USING btree (id)
+index	keys_usage_idx	CREATE INDEX keys_usage_idx ON public.keys USING btree (usage)
+relation	active_keys	v AS  SELECT id,\n    private_key,\n    public_key,\n    usage,\n    created_at,\n    expires_at,\n    deleted_at,\n    deleted_comment\n   FROM keys\n  WHERE expires_at > CURRENT_TIMESTAMP AND (deleted_at IS NULL OR deleted_at > CURRENT_TIMESTAMP);
+relation	keys	r
+schema	public	pg_database_owner=UC/pg_database_owner,=U/pg_database_owner


### PR DESCRIPTION
## Summary

- verify the keys migration through forward, fixture, rollback, and replay cycles
- exercise active, expired, and revoked view outcomes with real rows
- snapshot the full `active_keys` definition behind an append-only CI gate

## Breaking changes

None.

## Test plan

- [x] migration roundtrip test on PostgreSQL 18
- [x] deterministic snapshot regeneration
- [x] `pnpm lint:ci` and `pnpm lint:go`
- [x] `a-novel test --type=go -y`
- [x] `a-novel build --type=go -y`

Closes #885.
Part of a-novel/.github#237.