### PR TITLE
ci(ci): use shared Go generation action

### DIFF
--- a/.github/workflows/approve-pr.yaml
+++ b/.github/workflows/approve-pr.yaml
@@ -25,7 +25,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: a-novel-kit/workflows/generic-actions/approve-pr@v1.27.1
+      - uses: a-novel-kit/workflows/generic-actions/approve-pr@v1.28.0
         with:
           pull_request: ${{ inputs.pull_request }}
           client_id: ${{ vars.AGENT_BOT_CLIENT_ID }}

--- a/.github/workflows/auto-approve-dependabot.yaml
+++ b/.github/workflows/auto-approve-dependabot.yaml
@@ -20,7 +20,7 @@ jobs:
     # the callee mints a scoped App token and declares permissions: {}; the caller sets the ceiling, so it must not hand down
     # the repository default.
     permissions: {}
-    uses: a-novel-kit/workflows/.github/workflows/auto-approve-dependabot-run.yaml@v1.27.1
+    uses: a-novel-kit/workflows/.github/workflows/auto-approve-dependabot-run.yaml@v1.28.0
     with:
       client_id: ${{ vars.AGENT_BOT_CLIENT_ID }}
       dependency_bot_login: ${{ vars.DEPENDENCY_BOT_LOGIN }}

--- a/.github/workflows/auto-assign-author.yaml
+++ b/.github/workflows/auto-assign-author.yaml
@@ -10,6 +10,6 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: a-novel-kit/workflows/generic-actions/assign-bot@v1.27.1
+      - uses: a-novel-kit/workflows/generic-actions/assign-bot@v1.28.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/derive-status.yaml
+++ b/.github/workflows/derive-status.yaml
@@ -25,7 +25,7 @@ jobs:
       pull-requests: read
       issues: read
     steps:
-      - uses: a-novel-kit/workflows/generic-actions/derive-status@v1.27.1
+      - uses: a-novel-kit/workflows/generic-actions/derive-status@v1.28.0
         with:
           client_id: ${{ vars.AGENT_BOT_CLIENT_ID }}
           app_private_key: ${{ secrets.AGENT_BOT_PRIVATE_KEY }}

--- a/.github/workflows/epic-freeze.yaml
+++ b/.github/workflows/epic-freeze.yaml
@@ -33,7 +33,7 @@ jobs:
     # a stray forward is sweep-only, so a per-PR run can never re-enqueue.
     permissions: {}
     steps:
-      - uses: a-novel-kit/workflows/generic-actions/detect-partial-landing@v1.27.1
+      - uses: a-novel-kit/workflows/generic-actions/detect-partial-landing@v1.28.0
         with:
           client_id: ${{ vars.AGENT_BOT_CLIENT_ID }}
           app_private_key: ${{ secrets.AGENT_BOT_PRIVATE_KEY }}

--- a/.github/workflows/epic-rollback.yaml
+++ b/.github/workflows/epic-rollback.yaml
@@ -52,7 +52,7 @@ jobs:
     # the repository default.
     permissions:
       contents: read
-    uses: a-novel-kit/workflows/.github/workflows/epic-rollback-run.yaml@v1.27.1
+    uses: a-novel-kit/workflows/.github/workflows/epic-rollback-run.yaml@v1.28.0
     with:
       epic_number: ${{ inputs.epic_number }}
       confirm: ${{ inputs.confirm }}

--- a/.github/workflows/hotfix.yaml
+++ b/.github/workflows/hotfix.yaml
@@ -51,7 +51,7 @@ jobs:
     permissions:
       contents: write
       actions: read
-    uses: a-novel-kit/workflows/.github/workflows/hotfix-run.yaml@v1.27.1
+    uses: a-novel-kit/workflows/.github/workflows/hotfix-run.yaml@v1.28.0
     with:
       line: ${{ inputs.line }}
       fix_ref: ${{ inputs.fix_ref }}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -22,12 +22,12 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Check schema snapshots
-        uses: a-novel-kit/workflows/generic-actions/check-append-only@v1.27.1
+        uses: a-novel-kit/workflows/generic-actions/check-append-only@v1.28.0
         with:
           path: internal/models/migrations/testdata/schema
           base: ${{ github.event.pull_request.base.sha }}
       - name: Check migration SQL
-        uses: a-novel-kit/workflows/generic-actions/check-append-only@v1.27.1
+        uses: a-novel-kit/workflows/generic-actions/check-append-only@v1.28.0
         with:
           path: ":(glob)internal/models/migrations/*.sql"
           base: ${{ github.event.pull_request.base.sha }}
@@ -56,25 +56,14 @@ jobs:
     env:
       POSTGRES_DSN: postgres://postgres:postgres@localhost:5432/postgres?sslmode=disable
     steps:
-      - uses: actions/checkout@v7
-        with:
-          persist-credentials: false
-      - uses: actions/setup-go@v7
-        with:
-          go-version-file: "go.mod"
-      - name: go generate
-        shell: bash
-        run: go generate ./...
-      - uses: a-novel-kit/workflows/generic-actions/check-changes@v1.27.1
-        with:
-          fail_message: go generate definitions are not up-to-date, please run 'go generate ./...' and commit the changes
+      - uses: a-novel-kit/workflows/go-actions/generate-go@v1.28.0
 
   lint-go:
     runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
-      - uses: a-novel-kit/workflows/go-actions/lint-go@v1.27.1
+      - uses: a-novel-kit/workflows/go-actions/lint-go@v1.28.0
 
   lint-proto:
     runs-on: ubuntu-latest
@@ -94,7 +83,7 @@ jobs:
       contents: read
       packages: read
     steps:
-      - uses: a-novel-kit/workflows/node-actions/lint-node@v1.27.1
+      - uses: a-novel-kit/workflows/node-actions/lint-node@v1.28.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           app_private_key: ${{ secrets.DEPENDENCY_BOT_PRIVATE_KEY }}
@@ -109,7 +98,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           persist-credentials: false
-      - uses: a-novel-kit/workflows/generic-actions/lint-dockerfile@v1.27.1
+      - uses: a-novel-kit/workflows/generic-actions/lint-dockerfile@v1.28.0
         with:
           # renovate: datasource=github-releases depName=hadolint/hadolint
           version: "2.14.0"
@@ -123,7 +112,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           persist-credentials: false
-      - uses: a-novel-kit/workflows/security-actions/lint-semgrep@v1.27.1
+      - uses: a-novel-kit/workflows/security-actions/lint-semgrep@v1.28.0
         with:
           ruleset: service
           # renovate: datasource=docker depName=semgrep/semgrep
@@ -139,7 +128,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           persist-credentials: false
-      - uses: a-novel-kit/workflows/security-actions/scan-secrets@v1.27.1
+      - uses: a-novel-kit/workflows/security-actions/scan-secrets@v1.28.0
         with:
           config: .gitleaks.toml
           # renovate: datasource=github-releases depName=gitleaks/gitleaks
@@ -155,7 +144,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           persist-credentials: false
-      - uses: a-novel-kit/workflows/security-actions/lint-workflows@v1.27.1
+      - uses: a-novel-kit/workflows/security-actions/lint-workflows@v1.28.0
         with:
           # renovate: datasource=docker depName=ghcr.io/zizmorcore/zizmor
           version: "1.28.0"
@@ -202,7 +191,7 @@ jobs:
         run: |
           go run ./cmd/rotate-keys
           go run ./cmd/rotate-keys
-      - uses: a-novel-kit/workflows/go-actions/test-go@v1.27.1
+      - uses: a-novel-kit/workflows/go-actions/test-go@v1.28.0
         id: test
         with:
           filter_extra_patterns: "| grep /internal | grep -v /protogen"
@@ -252,7 +241,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           persist-credentials: false
-      - uses: a-novel-kit/workflows/go-actions/test-go@v1.27.1
+      - uses: a-novel-kit/workflows/go-actions/test-go@v1.28.0
         id: test
         with:
           filter_extra_patterns: "| grep /pkg"
@@ -300,7 +289,7 @@ jobs:
     env:
       REST_URL: "http://localhost:8080"
     steps:
-      - uses: a-novel-kit/workflows/node-actions/test-node@v1.27.1
+      - uses: a-novel-kit/workflows/node-actions/test-node@v1.28.0
         id: test
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -325,7 +314,7 @@ jobs:
       POSTGRES_HOST_AUTH_METHOD: scram-sha-256
       POSTGRES_INITDB_ARGS: --auth=scram-sha-256
     steps:
-      - uses: a-novel-kit/workflows/build-actions/docker@v1.27.1
+      - uses: a-novel-kit/workflows/build-actions/docker@v1.28.0
         id: build
         with:
           file: builds/database.Dockerfile
@@ -366,7 +355,7 @@ jobs:
     env:
       POSTGRES_DSN: postgres://postgres:postgres@localhost:5432/postgres?sslmode=disable
     steps:
-      - uses: a-novel-kit/workflows/build-actions/docker-job@v1.27.1
+      - uses: a-novel-kit/workflows/build-actions/docker-job@v1.28.0
         with:
           file: builds/migrations.Dockerfile
           image_name: ${{ github.repository }}/jobs/migrations
@@ -405,7 +394,7 @@ jobs:
         with:
           persist-credentials: false
       - uses: ./.github/actions/run-migrations
-      - uses: a-novel-kit/workflows/build-actions/docker-job@v1.27.1
+      - uses: a-novel-kit/workflows/build-actions/docker-job@v1.28.0
         with:
           file: builds/rotate-keys.Dockerfile
           image_name: ${{ github.repository }}/jobs/rotatekeys
@@ -444,7 +433,7 @@ jobs:
         with:
           persist-credentials: false
       - uses: ./.github/actions/run-migrations
-      - uses: a-novel-kit/workflows/build-actions/docker@v1.27.1
+      - uses: a-novel-kit/workflows/build-actions/docker@v1.28.0
         with:
           file: builds/grpc.Dockerfile
           image_name: ${{ github.repository }}/grpc
@@ -463,7 +452,7 @@ jobs:
     # test-pkg boots and exercises this image in a full integration run, so this job only
     # builds and pushes it; skip_healthcheck drops the redundant smoke run.
     steps:
-      - uses: a-novel-kit/workflows/build-actions/docker@v1.27.1
+      - uses: a-novel-kit/workflows/build-actions/docker@v1.28.0
         id: build
         with:
           file: builds/standalone.grpc.Dockerfile
@@ -503,7 +492,7 @@ jobs:
         with:
           persist-credentials: false
       - uses: ./.github/actions/run-migrations
-      - uses: a-novel-kit/workflows/build-actions/docker@v1.27.1
+      - uses: a-novel-kit/workflows/build-actions/docker@v1.28.0
         with:
           file: builds/rest.Dockerfile
           image_name: ${{ github.repository }}/rest
@@ -522,7 +511,7 @@ jobs:
     # test-pkg-js boots and exercises this image in a full integration run, so this job only
     # builds and pushes it; skip_healthcheck drops the redundant smoke run.
     steps:
-      - uses: a-novel-kit/workflows/build-actions/docker@v1.27.1
+      - uses: a-novel-kit/workflows/build-actions/docker@v1.28.0
         id: build
         with:
           file: builds/standalone.rest.Dockerfile
@@ -536,7 +525,7 @@ jobs:
       contents: read
       packages: read
     steps:
-      - uses: a-novel-kit/workflows/node-actions/build-node@v1.27.1
+      - uses: a-novel-kit/workflows/node-actions/build-node@v1.28.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           app_private_key: ${{ secrets.DEPENDENCY_BOT_PRIVATE_KEY }}
@@ -549,7 +538,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: a-novel-kit/workflows/generic-actions/codecov@v1.27.1
+      - uses: a-novel-kit/workflows/generic-actions/codecov@v1.28.0
         with:
           codecov_token: ${{ secrets.CODECOV_TOKEN }}
           coverage_files: coverage.txt,coverage_pkg.txt,coverage/*

--- a/.github/workflows/merge-gate.yaml
+++ b/.github/workflows/merge-gate.yaml
@@ -34,7 +34,7 @@ jobs:
     # the callee mints its own App token and declares permissions: {}; the caller sets the ceiling, so it must not hand down
     # the repository default.
     permissions: {}
-    uses: a-novel-kit/workflows/.github/workflows/merge-gate-run.yaml@v1.27.1
+    uses: a-novel-kit/workflows/.github/workflows/merge-gate-run.yaml@v1.28.0
     with:
       client_id: ${{ vars.AGENT_BOT_CLIENT_ID }}
       kill_switch: ${{ vars.AGENT_KILL_SWITCH }}

--- a/.github/workflows/node-audit.yaml
+++ b/.github/workflows/node-audit.yaml
@@ -11,7 +11,7 @@ jobs:
       contents: write
       packages: read
     steps:
-      - uses: a-novel-kit/workflows/node-actions/audit@v1.27.1
+      - uses: a-novel-kit/workflows/node-actions/audit@v1.28.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           app_private_key: ${{ secrets.PUBLISH_BOT_PRIVATE_KEY }}

--- a/.github/workflows/release-train.yaml
+++ b/.github/workflows/release-train.yaml
@@ -39,7 +39,7 @@ jobs:
     # the repository default.
     permissions:
       contents: read
-    uses: a-novel-kit/workflows/.github/workflows/release-train-run.yaml@v1.27.1
+    uses: a-novel-kit/workflows/.github/workflows/release-train-run.yaml@v1.28.0
     with:
       client_id: ${{ vars.AGENT_BOT_CLIENT_ID }}
       epic_number: ${{ inputs.epic_number }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -47,7 +47,7 @@ jobs:
       tag: ${{ steps.core.outputs.tag }}
     steps:
       - id: core
-        uses: a-novel-kit/workflows/publish-actions/release-core@v1.27.1
+        uses: a-novel-kit/workflows/publish-actions/release-core@v1.28.0
         with:
           # renovate: datasource=go depName=github.com/a-novel-kit/stack/cli
           cli_version: "1.7.5"
@@ -72,7 +72,7 @@ jobs:
       POSTGRES_HOST_AUTH_METHOD: scram-sha-256
       POSTGRES_INITDB_ARGS: --auth=scram-sha-256
     steps:
-      - uses: a-novel-kit/workflows/build-actions/docker@v1.27.1
+      - uses: a-novel-kit/workflows/build-actions/docker@v1.28.0
         with:
           file: builds/database.Dockerfile
           image_name: ${{ github.repository }}/database
@@ -114,7 +114,7 @@ jobs:
     env:
       POSTGRES_DSN: postgres://postgres:postgres@localhost:5432/postgres?sslmode=disable
     steps:
-      - uses: a-novel-kit/workflows/build-actions/docker-job@v1.27.1
+      - uses: a-novel-kit/workflows/build-actions/docker-job@v1.28.0
         with:
           file: builds/migrations.Dockerfile
           image_name: ${{ github.repository }}/jobs/migrations
@@ -155,7 +155,7 @@ jobs:
         with:
           persist-credentials: false
       - uses: ./.github/actions/run-migrations
-      - uses: a-novel-kit/workflows/build-actions/docker-job@v1.27.1
+      - uses: a-novel-kit/workflows/build-actions/docker-job@v1.28.0
         with:
           file: builds/rotate-keys.Dockerfile
           image_name: ${{ github.repository }}/jobs/rotatekeys
@@ -196,7 +196,7 @@ jobs:
         with:
           persist-credentials: false
       - uses: ./.github/actions/run-migrations
-      - uses: a-novel-kit/workflows/build-actions/docker@v1.27.1
+      - uses: a-novel-kit/workflows/build-actions/docker@v1.28.0
         with:
           file: builds/grpc.Dockerfile
           image_name: ${{ github.repository }}/grpc
@@ -237,7 +237,7 @@ jobs:
         with:
           persist-credentials: false
       - uses: ./.github/actions/run-migrations
-      - uses: a-novel-kit/workflows/build-actions/docker@v1.27.1
+      - uses: a-novel-kit/workflows/build-actions/docker@v1.28.0
         with:
           file: builds/standalone.grpc.Dockerfile
           image_name: ${{ github.repository }}/standalone-grpc
@@ -278,7 +278,7 @@ jobs:
         with:
           persist-credentials: false
       - uses: ./.github/actions/run-migrations
-      - uses: a-novel-kit/workflows/build-actions/docker@v1.27.1
+      - uses: a-novel-kit/workflows/build-actions/docker@v1.28.0
         with:
           file: builds/rest.Dockerfile
           image_name: ${{ github.repository }}/rest
@@ -319,7 +319,7 @@ jobs:
         with:
           persist-credentials: false
       - uses: ./.github/actions/run-migrations
-      - uses: a-novel-kit/workflows/build-actions/docker@v1.27.1
+      - uses: a-novel-kit/workflows/build-actions/docker@v1.28.0
         with:
           file: builds/standalone.rest.Dockerfile
           image_name: ${{ github.repository }}/standalone-rest
@@ -336,7 +336,7 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: a-novel-kit/workflows/publish-actions/npm@v1.27.1
+      - uses: a-novel-kit/workflows/publish-actions/npm@v1.28.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           app_private_key: ${{ secrets.PUBLISH_BOT_PRIVATE_KEY }}
@@ -360,7 +360,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: a-novel-kit/workflows/generic-actions/archive-board-items@v1.27.1
+      - uses: a-novel-kit/workflows/generic-actions/archive-board-items@v1.28.0
         with:
           client_id: ${{ vars.AGENT_BOT_CLIENT_ID }}
           app_private_key: ${{ secrets.AGENT_BOT_PRIVATE_KEY }}

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -18,7 +18,7 @@ jobs:
       id-token: write
       security-events: read
     steps:
-      - uses: a-novel-kit/workflows/generic-actions/renovate@v1.27.1
+      - uses: a-novel-kit/workflows/generic-actions/renovate@v1.28.0
         with:
           allowed_commands: |
             [


### PR DESCRIPTION
## Summary

- Replaces the repository-local generated-Go CI sequence with `generate-go@v1.28.0`.
- Preserves caller-owned job services and dependencies.
- Aligns all shared workflow-action references on the released `v1.28.0` tag.

## Layers changed

- **CI**: generated-code verification and shared-action pins.

## Breaking changes

None.

## Test plan

- [x] Repository Prettier check passes.
- [x] Focused workflow diff review and stale-pin guard pass.
- [ ] CI green

Closes #891

Part of a-novel/.github#239.