### PR TITLE
ci(ci): centralize service topology with Compose

### DIFF
--- a/.github/actions/start-ci-services/action.yml
+++ b/.github/actions/start-ci-services/action.yml
@@ -1,0 +1,67 @@
+name: start-ci-services
+description: Start and wait for the requested CI Compose topology.
+
+inputs:
+  services:
+    required: true
+    description: Space-separated Compose services to start.
+  database_image:
+    required: false
+    default: service-json-keys-database:ci
+    description: Database image reference used by the CI topology.
+  standalone_grpc_image:
+    required: false
+    default: service-json-keys-standalone-grpc:ci
+    description: Standalone gRPC image reference used by the CI topology.
+  standalone_rest_image:
+    required: false
+    default: service-json-keys-standalone-rest:ci
+    description: Standalone REST image reference used by the CI topology.
+  registry_login:
+    required: false
+    default: "false"
+    description: When "true", authenticate to ghcr.io with the current job token.
+
+runs:
+  using: composite
+  steps:
+    - name: Log in to the container registry
+      if: inputs.registry_login == 'true'
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+        REGISTRY_USERNAME: ${{ github.actor }}
+      run: |
+        set -euo pipefail
+        printf '%s' "${GH_TOKEN}" | docker login ghcr.io --username "${REGISTRY_USERNAME}" --password-stdin
+
+    - name: Start CI services
+      shell: bash
+      env:
+        CI_SERVICES: ${{ inputs.services }}
+        COMPOSE_PROJECT_NAME: ci-${{ github.job }}-${{ github.run_id }}-${{ github.run_attempt }}
+        DATABASE_IMAGE: ${{ inputs.database_image }}
+        STANDALONE_GRPC_IMAGE: ${{ inputs.standalone_grpc_image }}
+        STANDALONE_REST_IMAGE: ${{ inputs.standalone_rest_image }}
+        POSTGRES_PASSWORD: postgres
+      run: |
+        set -euo pipefail
+        read -r -a services <<< "${CI_SERVICES}"
+
+        set +e
+        docker compose --file builds/compose.ci.yaml up \
+          --detach \
+          --no-build \
+          --wait \
+          --wait-timeout 120 \
+          "${services[@]}"
+        status=$?
+        set -e
+
+        if (( status == 0 )); then
+          exit 0
+        fi
+
+        docker compose --file builds/compose.ci.yaml ps --all || true
+        docker compose --file builds/compose.ci.yaml logs --no-color || true
+        exit "${status}"

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -37,25 +37,19 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    services:
-      postgres:
-        image: ghcr.io/a-novel/service-json-keys/database@${{ needs.build-database.outputs.digest }}
-        ports:
-          - "5432:5432"
-        env:
-          POSTGRES_PASSWORD: postgres
-          POSTGRES_USER: postgres
-          POSTGRES_DB: postgres
-          POSTGRES_HOST_AUTH_METHOD: scram-sha-256
-          POSTGRES_INITDB_ARGS: --auth=scram-sha-256
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
+      packages: read
     env:
       POSTGRES_DSN: postgres://postgres:postgres@localhost:5432/postgres?sslmode=disable
     steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - &start-local-database
+        uses: ./.github/actions/start-ci-services
+        with:
+          services: postgres
+          database_image: ghcr.io/a-novel/service-json-keys/database@${{ needs.build-database.outputs.digest }}
+          registry_login: "true"
       - uses: a-novel-kit/workflows/go-actions/generate-go@v1.28.0
 
   lint-go:
@@ -154,24 +148,9 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      packages: read
     outputs:
       artifact-id: ${{ steps.test.outputs.artifact-id }}
-    services:
-      postgres:
-        image: ghcr.io/a-novel/service-json-keys/database@${{ needs.build-database.outputs.digest }}
-        ports:
-          - "5432:5432"
-        env:
-          POSTGRES_PASSWORD: postgres
-          POSTGRES_USER: postgres
-          POSTGRES_DB: postgres
-          POSTGRES_HOST_AUTH_METHOD: scram-sha-256
-          POSTGRES_INITDB_ARGS: --auth=scram-sha-256
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
     env:
       POSTGRES_DSN: postgres://postgres:postgres@localhost:5432/postgres?sslmode=disable
       APP_MASTER_KEY: "fec0681a2f57242211c559ca347721766f8a3acd8ed2e63b36b3768051c702ca"
@@ -179,6 +158,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           persist-credentials: false
+      - *start-local-database
       - uses: ./.github/actions/run-migrations
       # The rotation job was built by CI and never run, so nothing exercised its
       # wiring: the config it loads, the database context it seeds, the services
@@ -206,41 +186,21 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      packages: read
     outputs:
       artifact-id: ${{ steps.test.outputs.artifact-id }}
-    services:
-      postgres-json-keys:
-        image: ghcr.io/a-novel/service-json-keys/database@${{ needs.build-database.outputs.digest }}
-        ports:
-          - "5432:5432"
-        env:
-          POSTGRES_PASSWORD: postgres
-          POSTGRES_USER: postgres
-          POSTGRES_DB: postgres
-          POSTGRES_HOST_AUTH_METHOD: scram-sha-256
-          POSTGRES_INITDB_ARGS: --auth=scram-sha-256
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-
-      service-json-keys:
-        image: ghcr.io/a-novel/service-json-keys/standalone-grpc@${{ needs.build-standalone-grpc.outputs.digest }}
-        ports:
-          - "8080:8080"
-        credentials:
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-        env:
-          POSTGRES_DSN: postgres://postgres:postgres@postgres-json-keys:5432/postgres?sslmode=disable
-          APP_MASTER_KEY: "fec0681a2f57242211c559ca347721766f8a3acd8ed2e63b36b3768051c702ca"
     env:
       GRPC_URL: "localhost:8080"
     steps:
       - uses: actions/checkout@v7
         with:
           persist-credentials: false
+      - uses: ./.github/actions/start-ci-services
+        with:
+          services: standalone-grpc
+          database_image: ghcr.io/a-novel/service-json-keys/database@${{ needs.build-database.outputs.digest }}
+          standalone_grpc_image: ghcr.io/a-novel/service-json-keys/standalone-grpc@${{ needs.build-standalone-grpc.outputs.digest }}
+          registry_login: "true"
       - uses: a-novel-kit/workflows/go-actions/test-go@v1.28.0
         id: test
         with:
@@ -259,36 +219,18 @@ jobs:
       packages: read
     outputs:
       artifact-id: ${{ steps.test.outputs.artifact-id }}
-    services:
-      postgres-json-keys:
-        image: ghcr.io/a-novel/service-json-keys/database@${{ needs.build-database.outputs.digest }}
-        ports:
-          - "5432:5432"
-        env:
-          POSTGRES_PASSWORD: postgres
-          POSTGRES_USER: postgres
-          POSTGRES_DB: postgres
-          POSTGRES_HOST_AUTH_METHOD: scram-sha-256
-          POSTGRES_INITDB_ARGS: --auth=scram-sha-256
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-
-      service-json-keys:
-        image: ghcr.io/a-novel/service-json-keys/standalone-rest@${{ needs.build-standalone-rest.outputs.digest }}
-        ports:
-          - "8080:8080"
-        credentials:
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-        env:
-          POSTGRES_DSN: postgres://postgres:postgres@postgres-json-keys:5432/postgres?sslmode=disable
-          APP_MASTER_KEY: "fec0681a2f57242211c559ca347721766f8a3acd8ed2e63b36b3768051c702ca"
     env:
       REST_URL: "http://localhost:8080"
     steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/start-ci-services
+        with:
+          services: standalone-rest
+          database_image: ghcr.io/a-novel/service-json-keys/database@${{ needs.build-database.outputs.digest }}
+          standalone_rest_image: ghcr.io/a-novel/service-json-keys/standalone-rest@${{ needs.build-standalone-rest.outputs.digest }}
+          registry_login: "true"
       - uses: a-novel-kit/workflows/node-actions/test-node@v1.28.0
         id: test
         with:
@@ -307,12 +249,6 @@ jobs:
       id-token: write
     outputs:
       digest: ${{ steps.build.outputs.digest }}
-    env:
-      POSTGRES_PASSWORD: postgres
-      POSTGRES_USER: postgres
-      POSTGRES_DB: postgres
-      POSTGRES_HOST_AUTH_METHOD: scram-sha-256
-      POSTGRES_INITDB_ARGS: --auth=scram-sha-256
     steps:
       - uses: a-novel-kit/workflows/build-actions/docker@v1.28.0
         id: build
@@ -321,12 +257,7 @@ jobs:
           image_name: ${{ github.repository }}/database
           cache: false
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          run_args: >-
-            -e POSTGRES_PASSWORD="${POSTGRES_PASSWORD}" 
-            -e POSTGRES_USER="${POSTGRES_USER}" 
-            -e POSTGRES_DB="${POSTGRES_DB}"
-            -e POSTGRES_HOST_AUTH_METHOD="${POSTGRES_HOST_AUTH_METHOD}"
-            -e POSTGRES_INITDB_ARGS="${POSTGRES_INITDB_ARGS}"
+          run_args: -e POSTGRES_PASSWORD=postgres
 
   build-migrations:
     runs-on: ubuntu-latest
@@ -336,25 +267,13 @@ jobs:
       packages: write
       attestations: write
       id-token: write
-    services:
-      postgres-json-keys:
-        image: ghcr.io/a-novel/service-json-keys/database@${{ needs.build-database.outputs.digest }}
-        ports:
-          - "5432:5432"
-        env:
-          POSTGRES_PASSWORD: postgres
-          POSTGRES_USER: postgres
-          POSTGRES_DB: postgres
-          POSTGRES_HOST_AUTH_METHOD: scram-sha-256
-          POSTGRES_INITDB_ARGS: --auth=scram-sha-256
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
     env:
       POSTGRES_DSN: postgres://postgres:postgres@localhost:5432/postgres?sslmode=disable
     steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - *start-local-database
       - uses: a-novel-kit/workflows/build-actions/docker-job@v1.28.0
         with:
           file: builds/migrations.Dockerfile
@@ -370,22 +289,6 @@ jobs:
       packages: write
       attestations: write
       id-token: write
-    services:
-      postgres-json-keys:
-        image: ghcr.io/a-novel/service-json-keys/database@${{ needs.build-database.outputs.digest }}
-        ports:
-          - "5432:5432"
-        env:
-          POSTGRES_PASSWORD: postgres
-          POSTGRES_USER: postgres
-          POSTGRES_DB: postgres
-          POSTGRES_HOST_AUTH_METHOD: scram-sha-256
-          POSTGRES_INITDB_ARGS: --auth=scram-sha-256
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
     env:
       POSTGRES_DSN: postgres://postgres:postgres@localhost:5432/postgres?sslmode=disable
       APP_MASTER_KEY: "fec0681a2f57242211c559ca347721766f8a3acd8ed2e63b36b3768051c702ca"
@@ -393,6 +296,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           persist-credentials: false
+      - *start-local-database
       - uses: ./.github/actions/run-migrations
       - uses: a-novel-kit/workflows/build-actions/docker-job@v1.28.0
         with:
@@ -409,22 +313,6 @@ jobs:
       packages: write
       attestations: write
       id-token: write
-    services:
-      postgres-json-keys:
-        image: ghcr.io/a-novel/service-json-keys/database@${{ needs.build-database.outputs.digest }}
-        ports:
-          - "5432:5432"
-        env:
-          POSTGRES_PASSWORD: postgres
-          POSTGRES_USER: postgres
-          POSTGRES_DB: postgres
-          POSTGRES_HOST_AUTH_METHOD: scram-sha-256
-          POSTGRES_INITDB_ARGS: --auth=scram-sha-256
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
     env:
       POSTGRES_DSN: postgres://postgres:postgres@localhost:5432/postgres?sslmode=disable
       APP_MASTER_KEY: "fec0681a2f57242211c559ca347721766f8a3acd8ed2e63b36b3768051c702ca"
@@ -432,6 +320,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           persist-credentials: false
+      - *start-local-database
       - uses: ./.github/actions/run-migrations
       - uses: a-novel-kit/workflows/build-actions/docker@v1.28.0
         with:
@@ -468,22 +357,6 @@ jobs:
       packages: write
       attestations: write
       id-token: write
-    services:
-      postgres-json-keys:
-        image: ghcr.io/a-novel/service-json-keys/database@${{ needs.build-database.outputs.digest }}
-        ports:
-          - "5432:5432"
-        env:
-          POSTGRES_PASSWORD: postgres
-          POSTGRES_USER: postgres
-          POSTGRES_DB: postgres
-          POSTGRES_HOST_AUTH_METHOD: scram-sha-256
-          POSTGRES_INITDB_ARGS: --auth=scram-sha-256
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
     env:
       POSTGRES_DSN: postgres://postgres:postgres@localhost:5432/postgres?sslmode=disable
       APP_MASTER_KEY: "fec0681a2f57242211c559ca347721766f8a3acd8ed2e63b36b3768051c702ca"
@@ -491,6 +364,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           persist-credentials: false
+      - *start-local-database
       - uses: ./.github/actions/run-migrations
       - uses: a-novel-kit/workflows/build-actions/docker@v1.28.0
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -65,12 +65,6 @@ jobs:
       packages: write
       attestations: write
       id-token: write
-    env:
-      POSTGRES_PASSWORD: postgres
-      POSTGRES_USER: postgres
-      POSTGRES_DB: postgres
-      POSTGRES_HOST_AUTH_METHOD: scram-sha-256
-      POSTGRES_INITDB_ARGS: --auth=scram-sha-256
     steps:
       - uses: a-novel-kit/workflows/build-actions/docker@v1.28.0
         with:
@@ -79,12 +73,7 @@ jobs:
           cache: false
           version: ${{ needs.release.outputs.version }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          run_args: >-
-            -e POSTGRES_PASSWORD="${POSTGRES_PASSWORD}" 
-            -e POSTGRES_USER="${POSTGRES_USER}" 
-            -e POSTGRES_DB="${POSTGRES_DB}"
-            -e POSTGRES_HOST_AUTH_METHOD="${POSTGRES_HOST_AUTH_METHOD}"
-            -e POSTGRES_INITDB_ARGS="${POSTGRES_INITDB_ARGS}"
+          run_args: -e POSTGRES_PASSWORD=postgres
 
   build-migrations:
     runs-on: ubuntu-latest
@@ -95,25 +84,18 @@ jobs:
       packages: write
       attestations: write
       id-token: write
-    services:
-      postgres-json-keys:
-        image: ghcr.io/a-novel/service-json-keys/database:${{ needs.release.outputs.tag }}
-        ports:
-          - "5432:5432"
-        env:
-          POSTGRES_PASSWORD: postgres
-          POSTGRES_USER: postgres
-          POSTGRES_DB: postgres
-          POSTGRES_HOST_AUTH_METHOD: scram-sha-256
-          POSTGRES_INITDB_ARGS: --auth=scram-sha-256
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
     env:
       POSTGRES_DSN: postgres://postgres:postgres@localhost:5432/postgres?sslmode=disable
     steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - &start-release-database
+        uses: ./.github/actions/start-ci-services
+        with:
+          services: postgres
+          database_image: ghcr.io/a-novel/service-json-keys/database:${{ needs.release.outputs.tag }}
+          registry_login: "true"
       - uses: a-novel-kit/workflows/build-actions/docker-job@v1.28.0
         with:
           file: builds/migrations.Dockerfile
@@ -131,22 +113,6 @@ jobs:
       packages: write
       attestations: write
       id-token: write
-    services:
-      postgres-json-keys:
-        image: ghcr.io/a-novel/service-json-keys/database:${{ needs.release.outputs.tag }}
-        ports:
-          - "5432:5432"
-        env:
-          POSTGRES_PASSWORD: postgres
-          POSTGRES_USER: postgres
-          POSTGRES_DB: postgres
-          POSTGRES_HOST_AUTH_METHOD: scram-sha-256
-          POSTGRES_INITDB_ARGS: --auth=scram-sha-256
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
     env:
       POSTGRES_DSN: postgres://postgres:postgres@localhost:5432/postgres?sslmode=disable
       APP_MASTER_KEY: "fec0681a2f57242211c559ca347721766f8a3acd8ed2e63b36b3768051c702ca"
@@ -154,6 +120,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           persist-credentials: false
+      - *start-release-database
       - uses: ./.github/actions/run-migrations
       - uses: a-novel-kit/workflows/build-actions/docker-job@v1.28.0
         with:
@@ -172,22 +139,6 @@ jobs:
       packages: write
       attestations: write
       id-token: write
-    services:
-      postgres-json-keys:
-        image: ghcr.io/a-novel/service-json-keys/database:${{ needs.release.outputs.tag }}
-        ports:
-          - "5432:5432"
-        env:
-          POSTGRES_PASSWORD: postgres
-          POSTGRES_USER: postgres
-          POSTGRES_DB: postgres
-          POSTGRES_HOST_AUTH_METHOD: scram-sha-256
-          POSTGRES_INITDB_ARGS: --auth=scram-sha-256
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
     env:
       POSTGRES_DSN: postgres://postgres:postgres@localhost:5432/postgres?sslmode=disable
       APP_MASTER_KEY: "fec0681a2f57242211c559ca347721766f8a3acd8ed2e63b36b3768051c702ca"
@@ -195,6 +146,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           persist-credentials: false
+      - *start-release-database
       - uses: ./.github/actions/run-migrations
       - uses: a-novel-kit/workflows/build-actions/docker@v1.28.0
         with:
@@ -213,22 +165,6 @@ jobs:
       packages: write
       attestations: write
       id-token: write
-    services:
-      postgres-json-keys:
-        image: ghcr.io/a-novel/service-json-keys/database:${{ needs.release.outputs.tag }}
-        ports:
-          - "5432:5432"
-        env:
-          POSTGRES_PASSWORD: postgres
-          POSTGRES_USER: postgres
-          POSTGRES_DB: postgres
-          POSTGRES_HOST_AUTH_METHOD: scram-sha-256
-          POSTGRES_INITDB_ARGS: --auth=scram-sha-256
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
     env:
       POSTGRES_DSN: postgres://postgres:postgres@localhost:5432/postgres?sslmode=disable
       APP_MASTER_KEY: "fec0681a2f57242211c559ca347721766f8a3acd8ed2e63b36b3768051c702ca"
@@ -236,6 +172,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           persist-credentials: false
+      - *start-release-database
       - uses: ./.github/actions/run-migrations
       - uses: a-novel-kit/workflows/build-actions/docker@v1.28.0
         with:
@@ -254,22 +191,6 @@ jobs:
       packages: write
       attestations: write
       id-token: write
-    services:
-      postgres-json-keys:
-        image: ghcr.io/a-novel/service-json-keys/database:${{ needs.release.outputs.tag }}
-        ports:
-          - "5432:5432"
-        env:
-          POSTGRES_PASSWORD: postgres
-          POSTGRES_USER: postgres
-          POSTGRES_DB: postgres
-          POSTGRES_HOST_AUTH_METHOD: scram-sha-256
-          POSTGRES_INITDB_ARGS: --auth=scram-sha-256
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
     env:
       POSTGRES_DSN: postgres://postgres:postgres@localhost:5432/postgres?sslmode=disable
       APP_MASTER_KEY: "fec0681a2f57242211c559ca347721766f8a3acd8ed2e63b36b3768051c702ca"
@@ -277,6 +198,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           persist-credentials: false
+      - *start-release-database
       - uses: ./.github/actions/run-migrations
       - uses: a-novel-kit/workflows/build-actions/docker@v1.28.0
         with:
@@ -295,22 +217,6 @@ jobs:
       packages: write
       attestations: write
       id-token: write
-    services:
-      postgres-json-keys:
-        image: ghcr.io/a-novel/service-json-keys/database:${{ needs.release.outputs.tag }}
-        ports:
-          - "5432:5432"
-        env:
-          POSTGRES_PASSWORD: postgres
-          POSTGRES_USER: postgres
-          POSTGRES_DB: postgres
-          POSTGRES_HOST_AUTH_METHOD: scram-sha-256
-          POSTGRES_INITDB_ARGS: --auth=scram-sha-256
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
     env:
       POSTGRES_DSN: postgres://postgres:postgres@localhost:5432/postgres?sslmode=disable
       APP_MASTER_KEY: "fec0681a2f57242211c559ca347721766f8a3acd8ed2e63b36b3768051c702ca"
@@ -318,6 +224,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           persist-credentials: false
+      - *start-release-database
       - uses: ./.github/actions/run-migrations
       - uses: a-novel-kit/workflows/build-actions/docker@v1.28.0
         with:

--- a/builds/compose.ci.yaml
+++ b/builds/compose.ci.yaml
@@ -1,0 +1,34 @@
+services:
+  postgres:
+    image: "${DATABASE_IMAGE:?DATABASE_IMAGE is required}"
+    ports:
+      - "5432:5432"
+    environment:
+      POSTGRES_PASSWORD: "${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}"
+    healthcheck:
+      test: ["CMD", "pg_isready"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  standalone-grpc:
+    image: "${STANDALONE_GRPC_IMAGE:?STANDALONE_GRPC_IMAGE is required}"
+    ports:
+      - "8080:8080"
+    depends_on:
+      postgres:
+        condition: service_healthy
+    environment:
+      POSTGRES_DSN: postgres://postgres:postgres@postgres:5432/postgres?sslmode=disable
+      APP_MASTER_KEY: "fec0681a2f57242211c559ca347721766f8a3acd8ed2e63b36b3768051c702ca"
+
+  standalone-rest:
+    image: "${STANDALONE_REST_IMAGE:?STANDALONE_REST_IMAGE is required}"
+    ports:
+      - "8080:8080"
+    depends_on:
+      postgres:
+        condition: service_healthy
+    environment:
+      POSTGRES_DSN: postgres://postgres:postgres@postgres:5432/postgres?sslmode=disable
+      APP_MASTER_KEY: "fec0681a2f57242211c559ca347721766f8a3acd8ed2e63b36b3768051c702ca"

--- a/builds/database.Dockerfile
+++ b/builds/database.Dockerfile
@@ -2,6 +2,8 @@
 # Run the migrations image separately after deployment to create the schema.
 FROM docker.io/library/postgres:18.4
 
+ENV POSTGRES_INITDB_ARGS=--auth=scram-sha-256
+
 ARG DEBIAN_FRONTEND=noninteractive
 
 # SQL script run on first container start to install PostgreSQL extensions.


### PR DESCRIPTION
## Summary

- Centralizes PostgreSQL, standalone gRPC, and standalone REST startup in one selective Compose topology.
- Preserves database, migration, key-rotation, gRPC, REST, and standalone image-build checks while passing exact digests to integration consumers.
- Removes duplicated job-level services from branch and release workflows; Compose only starts images with `--no-build`.
- Makes SCRAM initialization a database-image default so database consumers pass only the password.

## Breaking changes

None.

## Test plan

- [x] `pnpm lint:stylecheck`
- [x] gRPC and REST Compose targets render with digest-pinned images
- [x] `builds/database.Dockerfile` builds with Podman
- [x] CI green (Epic merge gate awaits member approvals)

Closes #895