### PR TITLE
feat(contracts)!: namespace JSON Keys APIs at v2

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,27 +14,27 @@ Once the service is up (`a-novel run start service-json-keys/grpc` and/or `.../r
 
 ```bash
 # REST: liveness
-curl http://localhost:${REST_PORT}/ping
+curl http://localhost:${REST_PORT}/v2/ping
 
 # REST: dependency check (Postgres ping)
-curl http://localhost:${REST_PORT}/healthcheck
+curl http://localhost:${REST_PORT}/v2/healthcheck
 
 # gRPC: dependency check
-grpcurl -plaintext localhost:${GRPC_PORT} StatusService/Status
+grpcurl -plaintext localhost:${GRPC_PORT} anovel.jsonkeys.v2.StatusService/Status
 ```
 
 ### Reading keys
 
 ```bash
 # REST: list active public keys for a usage
-curl "http://localhost:${REST_PORT}/jwks?usage=auth"
+curl "http://localhost:${REST_PORT}/v2/jwks?usage=auth"
 
 # REST: fetch a single public key by ID
-curl "http://localhost:${REST_PORT}/jwk?id=<key-uuid>"
+curl "http://localhost:${REST_PORT}/v2/jwk?id=<key-uuid>"
 
 # gRPC: same operations through the private API
-grpcurl -plaintext -d '{"usage":"auth"}' localhost:${GRPC_PORT} JwkListService/JwkList
-grpcurl -plaintext -d '{"id":"<key-uuid>"}' localhost:${GRPC_PORT} JwkGetService/JwkGet
+grpcurl -plaintext -d '{"usage":"auth"}' localhost:${GRPC_PORT} anovel.jsonkeys.v2.JwkListService/JwkList
+grpcurl -plaintext -d '{"id":"<key-uuid>"}' localhost:${GRPC_PORT} anovel.jsonkeys.v2.JwkGetService/JwkGet
 ```
 
 ### Signing claims (gRPC only)
@@ -45,7 +45,7 @@ Signing requires the master key (`APP_MASTER_KEY`) and is only exposed over the 
 grpcurl -plaintext \
   -d '{"usage":"auth","payload":{"@type":"type.googleapis.com/google.protobuf.Struct","value":{"userID":"user-1"}}}' \
   localhost:${GRPC_PORT} \
-  ClaimsSignService/ClaimsSign
+  anovel.jsonkeys.v2.ClaimsSignService/ClaimsSign
 ```
 
 ---
@@ -103,10 +103,10 @@ This job is **not optional** for a long-running deployment. Existing keys age ou
 
 ### APIs
 
-| API               | Audience                       | Operations                                                              | Spec                                                 |
-| ----------------- | ------------------------------ | ----------------------------------------------------------------------- | ---------------------------------------------------- |
-| gRPC (`cmd/grpc`) | Internal, private network only | `StatusService`, `JwkGetService`, `JwkListService`, `ClaimsSignService` | [`internal/models/proto/`](./internal/models/proto/) |
-| REST (`cmd/rest`) | Public, unauthenticated        | `/ping`, `/healthcheck`, `/jwks`, `/jwk`                                | [`openapi.yaml`](./openapi.yaml)                     |
+| API               | Audience                       | Operations                                           | Spec                                                                                       |
+| ----------------- | ------------------------------ | ---------------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| gRPC (`cmd/grpc`) | Internal, private network only | `anovel.jsonkeys.v2` services                        | [`internal/models/proto/anovel/jsonkeys/v2/`](./internal/models/proto/anovel/jsonkeys/v2/) |
+| REST (`cmd/rest`) | Public, unauthenticated        | `/v2/ping`, `/v2/healthcheck`, `/v2/jwks`, `/v2/jwk` | [`openapi.yaml`](./openapi.yaml)                                                           |
 
 The REST server never exposes private keys or signing operations. The split is enforced structurally by registering the signing handler only inside [`cmd/grpc/main.go`](./cmd/grpc/main.go). The gRPC server itself implements no application-layer authentication — access control on that server is enforced entirely by deployment infrastructure (network policy, ingress, service mesh).
 

--- a/buf.gen.yaml
+++ b/buf.gen.yaml
@@ -3,7 +3,7 @@ managed:
   enabled: true
   override:
     - file_option: go_package_prefix
-      value: github.com/a-novel/service-json-keys/v2/internal/handlers/protogen;protogen
+      value: github.com/a-novel/service-json-keys/v2/internal/handlers/protogen
 plugins:
   - remote: buf.build/protocolbuffers/go
     out: internal/handlers/protogen

--- a/buf.yaml
+++ b/buf.yaml
@@ -5,8 +5,6 @@ modules:
 lint:
   use:
     - STANDARD
-  except:
-    - PACKAGE_DEFINED
 breaking:
   use:
     - FILE

--- a/builds/rest.Dockerfile
+++ b/builds/rest.Dockerfile
@@ -27,7 +27,7 @@ COPY --from=builder /rest /rest
 
 # Alpine ships BusyBox wget — no extra package needed for the healthcheck.
 HEALTHCHECK --interval=1s --timeout=5s --retries=10 --start-period=1s \
-  CMD wget -qO /dev/null http://localhost:8080/ping || exit 1
+  CMD wget -qO /dev/null http://localhost:8080/v2/ping || exit 1
 
 ENV REST_PORT=8080
 

--- a/builds/standalone.rest.Dockerfile
+++ b/builds/standalone.rest.Dockerfile
@@ -35,7 +35,7 @@ COPY --from=builder /rotate-keys /rotate-keys
 
 # Alpine ships BusyBox wget — no extra package needed for the healthcheck.
 HEALTHCHECK --interval=1s --timeout=5s --retries=10 --start-period=1s \
-  CMD wget -qO /dev/null http://localhost:8080/ping || exit 1
+  CMD wget -qO /dev/null http://localhost:8080/v2/ping || exit 1
 
 ENV REST_PORT=8080
 

--- a/cmd/grpc/main.go
+++ b/cmd/grpc/main.go
@@ -29,7 +29,7 @@ import (
 	"github.com/a-novel/service-json-keys/v2/internal/core"
 	"github.com/a-novel/service-json-keys/v2/internal/dao"
 	"github.com/a-novel/service-json-keys/v2/internal/handlers"
-	"github.com/a-novel/service-json-keys/v2/internal/handlers/protogen"
+	jsonkeysv2 "github.com/a-novel/service-json-keys/v2/internal/handlers/protogen/anovel/jsonkeys/v2"
 	"github.com/a-novel/service-json-keys/v2/internal/lib"
 )
 
@@ -110,10 +110,10 @@ func main() {
 
 	grpcf.SetEchoServersContext(ctx, server, cfg.Grpc.Ping)
 
-	protogen.RegisterStatusServiceServer(server, handlerStatus)
-	protogen.RegisterClaimsSignServiceServer(server, handlerClaimsSign)
-	protogen.RegisterJwkGetServiceServer(server, handlerJwkGet)
-	protogen.RegisterJwkListServiceServer(server, handlerJwkList)
+	jsonkeysv2.RegisterStatusServiceServer(server, handlerStatus)
+	jsonkeysv2.RegisterClaimsSignServiceServer(server, handlerClaimsSign)
+	jsonkeysv2.RegisterJwkGetServiceServer(server, handlerJwkGet)
+	jsonkeysv2.RegisterJwkListServiceServer(server, handlerJwkList)
 
 	reflection.Register(server)
 

--- a/cmd/rest/main.go
+++ b/cmd/rest/main.go
@@ -95,10 +95,12 @@ func main() {
 	}))
 	router.Use(cfg.RestLogger.Logger())
 
-	router.Get("/ping", handlerPing.ServeHTTP)
-	router.Get("/healthcheck", handlerHealth.ServeHTTP)
-	router.Get("/jwks", handlerJwkList.ServeHTTP)
-	router.Get("/jwk", handlerJwkGet.ServeHTTP)
+	router.Route("/v2", func(api chi.Router) {
+		api.Get("/ping", handlerPing.ServeHTTP)
+		api.Get("/healthcheck", handlerHealth.ServeHTTP)
+		api.Get("/jwks", handlerJwkList.ServeHTTP)
+		api.Get("/jwk", handlerJwkGet.ServeHTTP)
+	})
 
 	// =================================================================================================================
 	// RUN

--- a/internal/handlers/grpc.claimsSign.go
+++ b/internal/handlers/grpc.claimsSign.go
@@ -11,7 +11,7 @@ import (
 	"github.com/a-novel-kit/golib/otel"
 
 	"github.com/a-novel/service-json-keys/v2/internal/core"
-	"github.com/a-novel/service-json-keys/v2/internal/handlers/protogen"
+	jsonkeysv2 "github.com/a-novel/service-json-keys/v2/internal/handlers/protogen/anovel/jsonkeys/v2"
 )
 
 // GrpcClaimsSignService is the service dependency of [GrpcClaimsSign].
@@ -21,7 +21,7 @@ type GrpcClaimsSignService interface {
 
 // GrpcClaimsSign is the gRPC handler that signs a set of claims and returns a compact JWT.
 type GrpcClaimsSign struct {
-	protogen.UnimplementedClaimsSignServiceServer
+	jsonkeysv2.UnimplementedClaimsSignServiceServer
 
 	service GrpcClaimsSignService
 }
@@ -32,8 +32,8 @@ func NewGrpcClaimsSign(service GrpcClaimsSignService) *GrpcClaimsSign {
 }
 
 func (handler *GrpcClaimsSign) ClaimsSign(
-	ctx context.Context, request *protogen.ClaimsSignRequest,
-) (*protogen.ClaimsSignResponse, error) {
+	ctx context.Context, request *jsonkeysv2.ClaimsSignRequest,
+) (*jsonkeysv2.ClaimsSignResponse, error) {
 	ctx, span := otel.Tracer().Start(ctx, "grpc.ClaimsSign")
 	defer span.End()
 
@@ -66,5 +66,5 @@ func (handler *GrpcClaimsSign) ClaimsSign(
 		return nil, status.Error(codes.Internal, "internal error")
 	}
 
-	return otel.ReportSuccess(span, &protogen.ClaimsSignResponse{Token: signed}), nil
+	return otel.ReportSuccess(span, &jsonkeysv2.ClaimsSignResponse{Token: signed}), nil
 }

--- a/internal/handlers/grpc.claimsSign_test.go
+++ b/internal/handlers/grpc.claimsSign_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/a-novel/service-json-keys/v2/internal/core"
 	"github.com/a-novel/service-json-keys/v2/internal/handlers"
 	handlersmocks "github.com/a-novel/service-json-keys/v2/internal/handlers/mocks"
-	"github.com/a-novel/service-json-keys/v2/internal/handlers/protogen"
+	jsonkeysv2 "github.com/a-novel/service-json-keys/v2/internal/handlers/protogen/anovel/jsonkeys/v2"
 )
 
 func TestGrpcClaimsSign(t *testing.T) {
@@ -32,11 +32,11 @@ func TestGrpcClaimsSign(t *testing.T) {
 	testCases := []struct {
 		name string
 
-		request *protogen.ClaimsSignRequest
+		request *jsonkeysv2.ClaimsSignRequest
 
 		serviceMock *serviceMock
 
-		expect       *protogen.ClaimsSignResponse
+		expect       *jsonkeysv2.ClaimsSignResponse
 		expectStatus codes.Code
 		// expectMessage is a fragment the status message must carry, so a caller
 		// can tell what to fix without reading the service's logs.
@@ -45,7 +45,7 @@ func TestGrpcClaimsSign(t *testing.T) {
 		{
 			name: "Success",
 
-			request: &protogen.ClaimsSignRequest{
+			request: &jsonkeysv2.ClaimsSignRequest{
 				Payload: lo.Must(grpcf.MarshalJSONAsAny(map[string]any{"message": "hello world"})),
 				Usage:   "test-usage",
 			},
@@ -56,14 +56,14 @@ func TestGrpcClaimsSign(t *testing.T) {
 			},
 
 			expectStatus: codes.OK,
-			expect: &protogen.ClaimsSignResponse{
+			expect: &jsonkeysv2.ClaimsSignResponse{
 				Token: "access-token",
 			},
 		},
 		{
 			name: "Error/InvalidPayload",
 
-			request: &protogen.ClaimsSignRequest{
+			request: &jsonkeysv2.ClaimsSignRequest{
 				// Payload not set — grpcf.UnmarshalJSONFromAny(nil) returns an error.
 				Usage: "test-usage",
 			},
@@ -73,7 +73,7 @@ func TestGrpcClaimsSign(t *testing.T) {
 		{
 			name: "Error/BadConfig",
 
-			request: &protogen.ClaimsSignRequest{
+			request: &jsonkeysv2.ClaimsSignRequest{
 				Payload: lo.Must(grpcf.MarshalJSONAsAny(map[string]any{"message": "hello world"})),
 				Usage:   "test-usage",
 			},
@@ -91,7 +91,7 @@ func TestGrpcClaimsSign(t *testing.T) {
 			// them nothing to correct.
 			name: "Error/ReservedClaim",
 
-			request: &protogen.ClaimsSignRequest{
+			request: &jsonkeysv2.ClaimsSignRequest{
 				Payload: lo.Must(grpcf.MarshalJSONAsAny(map[string]any{"sub": "attacker"})),
 				Usage:   "test-usage",
 			},
@@ -107,7 +107,7 @@ func TestGrpcClaimsSign(t *testing.T) {
 		{
 			name: "Error/Internal",
 
-			request: &protogen.ClaimsSignRequest{
+			request: &jsonkeysv2.ClaimsSignRequest{
 				Payload: lo.Must(grpcf.MarshalJSONAsAny(map[string]any{"message": "hello world"})),
 				Usage:   "test-usage",
 			},

--- a/internal/handlers/grpc.jwkGet.go
+++ b/internal/handlers/grpc.jwkGet.go
@@ -11,7 +11,7 @@ import (
 	"github.com/a-novel-kit/golib/otel"
 
 	"github.com/a-novel/service-json-keys/v2/internal/core"
-	"github.com/a-novel/service-json-keys/v2/internal/handlers/protogen"
+	jsonkeysv2 "github.com/a-novel/service-json-keys/v2/internal/handlers/protogen/anovel/jsonkeys/v2"
 )
 
 // GrpcJwkGetService is the service dependency of [GrpcJwkGet].
@@ -21,7 +21,7 @@ type GrpcJwkGetService interface {
 
 // GrpcJwkGet is the gRPC handler that retrieves a single JSON Web Key by its ID.
 type GrpcJwkGet struct {
-	protogen.UnimplementedJwkGetServiceServer
+	jsonkeysv2.UnimplementedJwkGetServiceServer
 
 	service GrpcJwkGetService
 }
@@ -32,8 +32,8 @@ func NewGrpcJwkGet(service GrpcJwkGetService) *GrpcJwkGet {
 }
 
 func (handler *GrpcJwkGet) JwkGet(
-	ctx context.Context, request *protogen.JwkGetRequest,
-) (*protogen.JwkGetResponse, error) {
+	ctx context.Context, request *jsonkeysv2.JwkGetRequest,
+) (*jsonkeysv2.JwkGetResponse, error) {
 	ctx, span := otel.Tracer().Start(ctx, "grpc.JwkGet")
 	defer span.End()
 
@@ -57,8 +57,8 @@ func (handler *GrpcJwkGet) JwkGet(
 		return nil, status.Error(codes.Internal, "internal error")
 	}
 
-	return otel.ReportSuccess(span, &protogen.JwkGetResponse{
-		Jwk: &protogen.Jwk{
+	return otel.ReportSuccess(span, &jsonkeysv2.JwkGetResponse{
+		Jwk: &jsonkeysv2.Jwk{
 			Kty:     jwk.KTY.String(),
 			Use:     jwk.Use.String(),
 			KeyOps:  jwk.KeyOps.Strings(),

--- a/internal/handlers/grpc.jwkGet_test.go
+++ b/internal/handlers/grpc.jwkGet_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/a-novel/service-json-keys/v2/internal/core"
 	"github.com/a-novel/service-json-keys/v2/internal/handlers"
 	handlersmocks "github.com/a-novel/service-json-keys/v2/internal/handlers/mocks"
-	"github.com/a-novel/service-json-keys/v2/internal/handlers/protogen"
+	jsonkeysv2 "github.com/a-novel/service-json-keys/v2/internal/handlers/protogen/anovel/jsonkeys/v2"
 )
 
 func TestGrpcJwkGet(t *testing.T) {
@@ -32,17 +32,17 @@ func TestGrpcJwkGet(t *testing.T) {
 	testCases := []struct {
 		name string
 
-		request *protogen.JwkGetRequest
+		request *jsonkeysv2.JwkGetRequest
 
 		serviceMock *serviceMock
 
-		expect       *protogen.JwkGetResponse
+		expect       *jsonkeysv2.JwkGetResponse
 		expectStatus codes.Code
 	}{
 		{
 			name: "Success",
 
-			request: &protogen.JwkGetRequest{
+			request: &jsonkeysv2.JwkGetRequest{
 				Id: "00000000-0000-0000-0000-000000000001",
 			},
 
@@ -60,8 +60,8 @@ func TestGrpcJwkGet(t *testing.T) {
 			},
 
 			expectStatus: codes.OK,
-			expect: &protogen.JwkGetResponse{
-				Jwk: &protogen.Jwk{
+			expect: &jsonkeysv2.JwkGetResponse{
+				Jwk: &jsonkeysv2.Jwk{
 					Kty:     "test-kty",
 					Use:     "test-use",
 					KeyOps:  []string{"sign", "verify"},
@@ -74,7 +74,7 @@ func TestGrpcJwkGet(t *testing.T) {
 		{
 			name: "Error/InvalidID",
 
-			request: &protogen.JwkGetRequest{
+			request: &jsonkeysv2.JwkGetRequest{
 				Id: "not-a-uuid",
 			},
 
@@ -83,7 +83,7 @@ func TestGrpcJwkGet(t *testing.T) {
 		{
 			name: "Error/NotFound",
 
-			request: &protogen.JwkGetRequest{
+			request: &jsonkeysv2.JwkGetRequest{
 				Id: "00000000-0000-0000-0000-000000000001",
 			},
 
@@ -96,7 +96,7 @@ func TestGrpcJwkGet(t *testing.T) {
 		{
 			name: "Error/Internal",
 
-			request: &protogen.JwkGetRequest{
+			request: &jsonkeysv2.JwkGetRequest{
 				Id: "00000000-0000-0000-0000-000000000001",
 			},
 

--- a/internal/handlers/grpc.jwkList.go
+++ b/internal/handlers/grpc.jwkList.go
@@ -10,7 +10,7 @@ import (
 	"github.com/a-novel-kit/golib/otel"
 
 	"github.com/a-novel/service-json-keys/v2/internal/core"
-	"github.com/a-novel/service-json-keys/v2/internal/handlers/protogen"
+	jsonkeysv2 "github.com/a-novel/service-json-keys/v2/internal/handlers/protogen/anovel/jsonkeys/v2"
 )
 
 // GrpcJwkListService is the service dependency of [GrpcJwkList].
@@ -20,7 +20,7 @@ type GrpcJwkListService interface {
 
 // GrpcJwkList is the gRPC handler that returns the active public keys for a given usage.
 type GrpcJwkList struct {
-	protogen.UnimplementedJwkListServiceServer
+	jsonkeysv2.UnimplementedJwkListServiceServer
 
 	service GrpcJwkListService
 }
@@ -31,8 +31,8 @@ func NewGrpcJwkList(service GrpcJwkListService) *GrpcJwkList {
 }
 
 func (handler *GrpcJwkList) JwkList(
-	ctx context.Context, request *protogen.JwkListRequest,
-) (*protogen.JwkListResponse, error) {
+	ctx context.Context, request *jsonkeysv2.JwkListRequest,
+) (*jsonkeysv2.JwkListResponse, error) {
 	ctx, span := otel.Tracer().Start(ctx, "grpc.JwkList")
 	defer span.End()
 
@@ -45,9 +45,9 @@ func (handler *GrpcJwkList) JwkList(
 		return nil, status.Error(codes.Internal, "internal error")
 	}
 
-	return otel.ReportSuccess(span, &protogen.JwkListResponse{
-		Keys: lo.Map(jwks, func(item *core.Jwk, index int) *protogen.Jwk {
-			return &protogen.Jwk{
+	return otel.ReportSuccess(span, &jsonkeysv2.JwkListResponse{
+		Keys: lo.Map(jwks, func(item *core.Jwk, index int) *jsonkeysv2.Jwk {
+			return &jsonkeysv2.Jwk{
 				Kty:     item.KTY.String(),
 				Use:     item.Use.String(),
 				KeyOps:  item.KeyOps.Strings(),

--- a/internal/handlers/grpc.jwkList_test.go
+++ b/internal/handlers/grpc.jwkList_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/a-novel/service-json-keys/v2/internal/core"
 	"github.com/a-novel/service-json-keys/v2/internal/handlers"
 	handlersmocks "github.com/a-novel/service-json-keys/v2/internal/handlers/mocks"
-	"github.com/a-novel/service-json-keys/v2/internal/handlers/protogen"
+	jsonkeysv2 "github.com/a-novel/service-json-keys/v2/internal/handlers/protogen/anovel/jsonkeys/v2"
 )
 
 func TestGrpcJwkList(t *testing.T) {
@@ -31,17 +31,17 @@ func TestGrpcJwkList(t *testing.T) {
 	testCases := []struct {
 		name string
 
-		request *protogen.JwkListRequest
+		request *jsonkeysv2.JwkListRequest
 
 		serviceMock *serviceMock
 
-		expect       *protogen.JwkListResponse
+		expect       *jsonkeysv2.JwkListResponse
 		expectStatus codes.Code
 	}{
 		{
 			name: "Success",
 
-			request: &protogen.JwkListRequest{
+			request: &jsonkeysv2.JwkListRequest{
 				Usage: "test-usage",
 			},
 
@@ -61,8 +61,8 @@ func TestGrpcJwkList(t *testing.T) {
 			},
 
 			expectStatus: codes.OK,
-			expect: &protogen.JwkListResponse{
-				Keys: []*protogen.Jwk{
+			expect: &jsonkeysv2.JwkListResponse{
+				Keys: []*jsonkeysv2.Jwk{
 					{
 						Kty:     "test-kty",
 						Use:     "test-use",
@@ -77,7 +77,7 @@ func TestGrpcJwkList(t *testing.T) {
 		{
 			name: "Success/Empty",
 
-			request: &protogen.JwkListRequest{
+			request: &jsonkeysv2.JwkListRequest{
 				Usage: "test-usage",
 			},
 
@@ -86,14 +86,14 @@ func TestGrpcJwkList(t *testing.T) {
 			},
 
 			expectStatus: codes.OK,
-			expect: &protogen.JwkListResponse{
-				Keys: []*protogen.Jwk{},
+			expect: &jsonkeysv2.JwkListResponse{
+				Keys: []*jsonkeysv2.Jwk{},
 			},
 		},
 		{
 			name: "Error/Internal",
 
-			request: &protogen.JwkListRequest{
+			request: &jsonkeysv2.JwkListRequest{
 				Usage: "test-usage",
 			},
 

--- a/internal/handlers/grpc.status.go
+++ b/internal/handlers/grpc.status.go
@@ -9,7 +9,7 @@ import (
 	"github.com/a-novel-kit/golib/otel"
 	"github.com/a-novel-kit/golib/postgres"
 
-	"github.com/a-novel/service-json-keys/v2/internal/handlers/protogen"
+	jsonkeysv2 "github.com/a-novel/service-json-keys/v2/internal/handlers/protogen/anovel/jsonkeys/v2"
 )
 
 // NewGrpcHealthStatus converts an error into a DependencyHealth proto message,
@@ -17,12 +17,12 @@ import (
 //
 // The error is dropped from the message: raw dependency errors embed internal hostnames,
 // ports and schema names. Operators read it from the trace span the failing probe records.
-func NewGrpcHealthStatus(err error) *protogen.DependencyHealth {
-	return &protogen.DependencyHealth{
+func NewGrpcHealthStatus(err error) *jsonkeysv2.DependencyHealth {
+	return &jsonkeysv2.DependencyHealth{
 		Status: lo.Ternary(
 			err == nil,
-			protogen.DependencyStatus_DEPENDENCY_STATUS_UP,
-			protogen.DependencyStatus_DEPENDENCY_STATUS_DOWN,
+			jsonkeysv2.DependencyStatus_DEPENDENCY_STATUS_UP,
+			jsonkeysv2.DependencyStatus_DEPENDENCY_STATUS_DOWN,
 		),
 	}
 }
@@ -30,7 +30,7 @@ func NewGrpcHealthStatus(err error) *protogen.DependencyHealth {
 // GrpcStatus is the gRPC handler that reports the operational health of the service
 // and its dependencies.
 type GrpcStatus struct {
-	protogen.UnimplementedStatusServiceServer
+	jsonkeysv2.UnimplementedStatusServiceServer
 }
 
 // NewGrpcStatus returns a new GrpcStatus handler.
@@ -38,11 +38,13 @@ func NewGrpcStatus() *GrpcStatus {
 	return &GrpcStatus{}
 }
 
-func (handler *GrpcStatus) Status(ctx context.Context, _ *protogen.StatusRequest) (*protogen.StatusResponse, error) {
+func (handler *GrpcStatus) Status(
+	ctx context.Context, _ *jsonkeysv2.StatusRequest,
+) (*jsonkeysv2.StatusResponse, error) {
 	ctx, span := otel.Tracer().Start(ctx, "grpc.Status")
 	defer span.End()
 
-	return otel.ReportSuccess(span, &protogen.StatusResponse{
+	return otel.ReportSuccess(span, &jsonkeysv2.StatusResponse{
 		Postgres: NewGrpcHealthStatus(handler.reportPostgres(ctx)),
 	}), nil
 }

--- a/internal/handlers/grpc.status_test.go
+++ b/internal/handlers/grpc.status_test.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/a-novel/service-json-keys/v2/internal/config/configtest"
 	"github.com/a-novel/service-json-keys/v2/internal/handlers"
-	"github.com/a-novel/service-json-keys/v2/internal/handlers/protogen"
+	jsonkeysv2 "github.com/a-novel/service-json-keys/v2/internal/handlers/protogen/anovel/jsonkeys/v2"
 )
 
 func TestGrpcStatus(t *testing.T) {
@@ -22,16 +22,16 @@ func TestGrpcStatus(t *testing.T) {
 
 		skipPostgres bool
 
-		expect       *protogen.StatusResponse
+		expect       *jsonkeysv2.StatusResponse
 		expectStatus codes.Code
 	}{
 		{
 			name: "Success",
 
 			expectStatus: codes.OK,
-			expect: &protogen.StatusResponse{
-				Postgres: &protogen.DependencyHealth{
-					Status: protogen.DependencyStatus_DEPENDENCY_STATUS_UP,
+			expect: &jsonkeysv2.StatusResponse{
+				Postgres: &jsonkeysv2.DependencyHealth{
+					Status: jsonkeysv2.DependencyStatus_DEPENDENCY_STATUS_UP,
 				},
 			},
 		},
@@ -45,9 +45,9 @@ func TestGrpcStatus(t *testing.T) {
 			skipPostgres: true,
 
 			expectStatus: codes.OK,
-			expect: &protogen.StatusResponse{
-				Postgres: &protogen.DependencyHealth{
-					Status: protogen.DependencyStatus_DEPENDENCY_STATUS_DOWN,
+			expect: &jsonkeysv2.StatusResponse{
+				Postgres: &jsonkeysv2.DependencyHealth{
+					Status: jsonkeysv2.DependencyStatus_DEPENDENCY_STATUS_DOWN,
 				},
 			},
 		},
@@ -68,7 +68,7 @@ func TestGrpcStatus(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			res, err := handler.Status(ctx, new(protogen.StatusRequest))
+			res, err := handler.Status(ctx, new(jsonkeysv2.StatusRequest))
 			resSt, ok := status.FromError(err)
 			require.True(t, ok, resSt.Code().String())
 			require.Equal(

--- a/internal/handlers/protogen/anovel/jsonkeys/v2/claims_sign.pb.go
+++ b/internal/handlers/protogen/anovel/jsonkeys/v2/claims_sign.pb.go
@@ -2,9 +2,9 @@
 // versions:
 // 	protoc-gen-go v1.36.11
 // 	protoc        (unknown)
-// source: claims_sign.proto
+// source: anovel/jsonkeys/v2/claims_sign.proto
 
-package protogen
+package jsonkeysv2
 
 import (
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
@@ -43,7 +43,7 @@ type ClaimsSignRequest struct {
 
 func (x *ClaimsSignRequest) Reset() {
 	*x = ClaimsSignRequest{}
-	mi := &file_claims_sign_proto_msgTypes[0]
+	mi := &file_anovel_jsonkeys_v2_claims_sign_proto_msgTypes[0]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -55,7 +55,7 @@ func (x *ClaimsSignRequest) String() string {
 func (*ClaimsSignRequest) ProtoMessage() {}
 
 func (x *ClaimsSignRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_claims_sign_proto_msgTypes[0]
+	mi := &file_anovel_jsonkeys_v2_claims_sign_proto_msgTypes[0]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -68,7 +68,7 @@ func (x *ClaimsSignRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ClaimsSignRequest.ProtoReflect.Descriptor instead.
 func (*ClaimsSignRequest) Descriptor() ([]byte, []int) {
-	return file_claims_sign_proto_rawDescGZIP(), []int{0}
+	return file_anovel_jsonkeys_v2_claims_sign_proto_rawDescGZIP(), []int{0}
 }
 
 func (x *ClaimsSignRequest) GetUsage() string {
@@ -96,7 +96,7 @@ type ClaimsSignResponse struct {
 
 func (x *ClaimsSignResponse) Reset() {
 	*x = ClaimsSignResponse{}
-	mi := &file_claims_sign_proto_msgTypes[1]
+	mi := &file_anovel_jsonkeys_v2_claims_sign_proto_msgTypes[1]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -108,7 +108,7 @@ func (x *ClaimsSignResponse) String() string {
 func (*ClaimsSignResponse) ProtoMessage() {}
 
 func (x *ClaimsSignResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_claims_sign_proto_msgTypes[1]
+	mi := &file_anovel_jsonkeys_v2_claims_sign_proto_msgTypes[1]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -121,7 +121,7 @@ func (x *ClaimsSignResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ClaimsSignResponse.ProtoReflect.Descriptor instead.
 func (*ClaimsSignResponse) Descriptor() ([]byte, []int) {
-	return file_claims_sign_proto_rawDescGZIP(), []int{1}
+	return file_anovel_jsonkeys_v2_claims_sign_proto_rawDescGZIP(), []int{1}
 }
 
 func (x *ClaimsSignResponse) GetToken() string {
@@ -131,42 +131,43 @@ func (x *ClaimsSignResponse) GetToken() string {
 	return ""
 }
 
-var File_claims_sign_proto protoreflect.FileDescriptor
+var File_anovel_jsonkeys_v2_claims_sign_proto protoreflect.FileDescriptor
 
-const file_claims_sign_proto_rawDesc = "" +
+const file_anovel_jsonkeys_v2_claims_sign_proto_rawDesc = "" +
 	"\n" +
-	"\x11claims_sign.proto\x1a\x19google/protobuf/any.proto\"Y\n" +
+	"$anovel/jsonkeys/v2/claims_sign.proto\x12\x12anovel.jsonkeys.v2\x1a\x19google/protobuf/any.proto\"Y\n" +
 	"\x11ClaimsSignRequest\x12\x14\n" +
 	"\x05usage\x18\x01 \x01(\tR\x05usage\x12.\n" +
 	"\apayload\x18\x02 \x01(\v2\x14.google.protobuf.AnyR\apayload\"*\n" +
 	"\x12ClaimsSignResponse\x12\x14\n" +
-	"\x05token\x18\x01 \x01(\tR\x05token2J\n" +
-	"\x11ClaimsSignService\x125\n" +
+	"\x05token\x18\x01 \x01(\tR\x05token2p\n" +
+	"\x11ClaimsSignService\x12[\n" +
 	"\n" +
-	"ClaimsSign\x12\x12.ClaimsSignRequest\x1a\x13.ClaimsSignResponseB`B\x0fClaimsSignProtoP\x01ZKgithub.com/a-novel/service-json-keys/v2/internal/handlers/protogen;protogenb\x06proto3"
+	"ClaimsSign\x12%.anovel.jsonkeys.v2.ClaimsSignRequest\x1a&.anovel.jsonkeys.v2.ClaimsSignResponseB\xf5\x01\n" +
+	"\x16com.anovel.jsonkeys.v2B\x0fClaimsSignProtoP\x01Z`github.com/a-novel/service-json-keys/v2/internal/handlers/protogen/anovel/jsonkeys/v2;jsonkeysv2\xa2\x02\x03AJX\xaa\x02\x12Anovel.Jsonkeys.V2\xca\x02\x12Anovel\\Jsonkeys\\V2\xe2\x02\x1eAnovel\\Jsonkeys\\V2\\GPBMetadata\xea\x02\x14Anovel::Jsonkeys::V2b\x06proto3"
 
 var (
-	file_claims_sign_proto_rawDescOnce sync.Once
-	file_claims_sign_proto_rawDescData []byte
+	file_anovel_jsonkeys_v2_claims_sign_proto_rawDescOnce sync.Once
+	file_anovel_jsonkeys_v2_claims_sign_proto_rawDescData []byte
 )
 
-func file_claims_sign_proto_rawDescGZIP() []byte {
-	file_claims_sign_proto_rawDescOnce.Do(func() {
-		file_claims_sign_proto_rawDescData = protoimpl.X.CompressGZIP(unsafe.Slice(unsafe.StringData(file_claims_sign_proto_rawDesc), len(file_claims_sign_proto_rawDesc)))
+func file_anovel_jsonkeys_v2_claims_sign_proto_rawDescGZIP() []byte {
+	file_anovel_jsonkeys_v2_claims_sign_proto_rawDescOnce.Do(func() {
+		file_anovel_jsonkeys_v2_claims_sign_proto_rawDescData = protoimpl.X.CompressGZIP(unsafe.Slice(unsafe.StringData(file_anovel_jsonkeys_v2_claims_sign_proto_rawDesc), len(file_anovel_jsonkeys_v2_claims_sign_proto_rawDesc)))
 	})
-	return file_claims_sign_proto_rawDescData
+	return file_anovel_jsonkeys_v2_claims_sign_proto_rawDescData
 }
 
-var file_claims_sign_proto_msgTypes = make([]protoimpl.MessageInfo, 2)
-var file_claims_sign_proto_goTypes = []any{
-	(*ClaimsSignRequest)(nil),  // 0: ClaimsSignRequest
-	(*ClaimsSignResponse)(nil), // 1: ClaimsSignResponse
+var file_anovel_jsonkeys_v2_claims_sign_proto_msgTypes = make([]protoimpl.MessageInfo, 2)
+var file_anovel_jsonkeys_v2_claims_sign_proto_goTypes = []any{
+	(*ClaimsSignRequest)(nil),  // 0: anovel.jsonkeys.v2.ClaimsSignRequest
+	(*ClaimsSignResponse)(nil), // 1: anovel.jsonkeys.v2.ClaimsSignResponse
 	(*anypb.Any)(nil),          // 2: google.protobuf.Any
 }
-var file_claims_sign_proto_depIdxs = []int32{
-	2, // 0: ClaimsSignRequest.payload:type_name -> google.protobuf.Any
-	0, // 1: ClaimsSignService.ClaimsSign:input_type -> ClaimsSignRequest
-	1, // 2: ClaimsSignService.ClaimsSign:output_type -> ClaimsSignResponse
+var file_anovel_jsonkeys_v2_claims_sign_proto_depIdxs = []int32{
+	2, // 0: anovel.jsonkeys.v2.ClaimsSignRequest.payload:type_name -> google.protobuf.Any
+	0, // 1: anovel.jsonkeys.v2.ClaimsSignService.ClaimsSign:input_type -> anovel.jsonkeys.v2.ClaimsSignRequest
+	1, // 2: anovel.jsonkeys.v2.ClaimsSignService.ClaimsSign:output_type -> anovel.jsonkeys.v2.ClaimsSignResponse
 	2, // [2:3] is the sub-list for method output_type
 	1, // [1:2] is the sub-list for method input_type
 	1, // [1:1] is the sub-list for extension type_name
@@ -174,26 +175,26 @@ var file_claims_sign_proto_depIdxs = []int32{
 	0, // [0:1] is the sub-list for field type_name
 }
 
-func init() { file_claims_sign_proto_init() }
-func file_claims_sign_proto_init() {
-	if File_claims_sign_proto != nil {
+func init() { file_anovel_jsonkeys_v2_claims_sign_proto_init() }
+func file_anovel_jsonkeys_v2_claims_sign_proto_init() {
+	if File_anovel_jsonkeys_v2_claims_sign_proto != nil {
 		return
 	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
-			RawDescriptor: unsafe.Slice(unsafe.StringData(file_claims_sign_proto_rawDesc), len(file_claims_sign_proto_rawDesc)),
+			RawDescriptor: unsafe.Slice(unsafe.StringData(file_anovel_jsonkeys_v2_claims_sign_proto_rawDesc), len(file_anovel_jsonkeys_v2_claims_sign_proto_rawDesc)),
 			NumEnums:      0,
 			NumMessages:   2,
 			NumExtensions: 0,
 			NumServices:   1,
 		},
-		GoTypes:           file_claims_sign_proto_goTypes,
-		DependencyIndexes: file_claims_sign_proto_depIdxs,
-		MessageInfos:      file_claims_sign_proto_msgTypes,
+		GoTypes:           file_anovel_jsonkeys_v2_claims_sign_proto_goTypes,
+		DependencyIndexes: file_anovel_jsonkeys_v2_claims_sign_proto_depIdxs,
+		MessageInfos:      file_anovel_jsonkeys_v2_claims_sign_proto_msgTypes,
 	}.Build()
-	File_claims_sign_proto = out.File
-	file_claims_sign_proto_goTypes = nil
-	file_claims_sign_proto_depIdxs = nil
+	File_anovel_jsonkeys_v2_claims_sign_proto = out.File
+	file_anovel_jsonkeys_v2_claims_sign_proto_goTypes = nil
+	file_anovel_jsonkeys_v2_claims_sign_proto_depIdxs = nil
 }

--- a/internal/handlers/protogen/anovel/jsonkeys/v2/claims_sign_grpc.pb.go
+++ b/internal/handlers/protogen/anovel/jsonkeys/v2/claims_sign_grpc.pb.go
@@ -2,9 +2,9 @@
 // versions:
 // - protoc-gen-go-grpc v1.6.2
 // - protoc             (unknown)
-// source: claims_sign.proto
+// source: anovel/jsonkeys/v2/claims_sign.proto
 
-package protogen
+package jsonkeysv2
 
 import (
 	context "context"
@@ -19,7 +19,7 @@ import (
 const _ = grpc.SupportPackageIsVersion9
 
 const (
-	ClaimsSignService_ClaimsSign_FullMethodName = "/ClaimsSignService/ClaimsSign"
+	ClaimsSignService_ClaimsSign_FullMethodName = "/anovel.jsonkeys.v2.ClaimsSignService/ClaimsSign"
 )
 
 // ClaimsSignServiceClient is the client API for ClaimsSignService service.
@@ -122,7 +122,7 @@ func _ClaimsSignService_ClaimsSign_Handler(srv interface{}, ctx context.Context,
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
 var ClaimsSignService_ServiceDesc = grpc.ServiceDesc{
-	ServiceName: "ClaimsSignService",
+	ServiceName: "anovel.jsonkeys.v2.ClaimsSignService",
 	HandlerType: (*ClaimsSignServiceServer)(nil),
 	Methods: []grpc.MethodDesc{
 		{
@@ -131,5 +131,5 @@ var ClaimsSignService_ServiceDesc = grpc.ServiceDesc{
 		},
 	},
 	Streams:  []grpc.StreamDesc{},
-	Metadata: "claims_sign.proto",
+	Metadata: "anovel/jsonkeys/v2/claims_sign.proto",
 }

--- a/internal/handlers/protogen/anovel/jsonkeys/v2/jwk.pb.go
+++ b/internal/handlers/protogen/anovel/jsonkeys/v2/jwk.pb.go
@@ -2,9 +2,9 @@
 // versions:
 // 	protoc-gen-go v1.36.11
 // 	protoc        (unknown)
-// source: jwk.proto
+// source: anovel/jsonkeys/v2/jwk.proto
 
-package protogen
+package jsonkeysv2
 
 import (
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
@@ -47,7 +47,7 @@ type Jwk struct {
 
 func (x *Jwk) Reset() {
 	*x = Jwk{}
-	mi := &file_jwk_proto_msgTypes[0]
+	mi := &file_anovel_jsonkeys_v2_jwk_proto_msgTypes[0]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -59,7 +59,7 @@ func (x *Jwk) String() string {
 func (*Jwk) ProtoMessage() {}
 
 func (x *Jwk) ProtoReflect() protoreflect.Message {
-	mi := &file_jwk_proto_msgTypes[0]
+	mi := &file_anovel_jsonkeys_v2_jwk_proto_msgTypes[0]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -72,7 +72,7 @@ func (x *Jwk) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Jwk.ProtoReflect.Descriptor instead.
 func (*Jwk) Descriptor() ([]byte, []int) {
-	return file_jwk_proto_rawDescGZIP(), []int{0}
+	return file_anovel_jsonkeys_v2_jwk_proto_rawDescGZIP(), []int{0}
 }
 
 func (x *Jwk) GetKty() string {
@@ -117,36 +117,37 @@ func (x *Jwk) GetPayload() []byte {
 	return nil
 }
 
-var File_jwk_proto protoreflect.FileDescriptor
+var File_anovel_jsonkeys_v2_jwk_proto protoreflect.FileDescriptor
 
-const file_jwk_proto_rawDesc = "" +
+const file_anovel_jsonkeys_v2_jwk_proto_rawDesc = "" +
 	"\n" +
-	"\tjwk.proto\"\x80\x01\n" +
+	"\x1canovel/jsonkeys/v2/jwk.proto\x12\x12anovel.jsonkeys.v2\"\x80\x01\n" +
 	"\x03Jwk\x12\x10\n" +
 	"\x03kty\x18\x01 \x01(\tR\x03kty\x12\x10\n" +
 	"\x03use\x18\x02 \x01(\tR\x03use\x12\x17\n" +
 	"\akey_ops\x18\x03 \x03(\tR\x06keyOps\x12\x10\n" +
 	"\x03alg\x18\x04 \x01(\tR\x03alg\x12\x10\n" +
 	"\x03kid\x18\x05 \x01(\tR\x03kid\x12\x18\n" +
-	"\apayload\x18\x06 \x01(\fR\apayloadBYB\bJwkProtoP\x01ZKgithub.com/a-novel/service-json-keys/v2/internal/handlers/protogen;protogenb\x06proto3"
+	"\apayload\x18\x06 \x01(\fR\apayloadB\xee\x01\n" +
+	"\x16com.anovel.jsonkeys.v2B\bJwkProtoP\x01Z`github.com/a-novel/service-json-keys/v2/internal/handlers/protogen/anovel/jsonkeys/v2;jsonkeysv2\xa2\x02\x03AJX\xaa\x02\x12Anovel.Jsonkeys.V2\xca\x02\x12Anovel\\Jsonkeys\\V2\xe2\x02\x1eAnovel\\Jsonkeys\\V2\\GPBMetadata\xea\x02\x14Anovel::Jsonkeys::V2b\x06proto3"
 
 var (
-	file_jwk_proto_rawDescOnce sync.Once
-	file_jwk_proto_rawDescData []byte
+	file_anovel_jsonkeys_v2_jwk_proto_rawDescOnce sync.Once
+	file_anovel_jsonkeys_v2_jwk_proto_rawDescData []byte
 )
 
-func file_jwk_proto_rawDescGZIP() []byte {
-	file_jwk_proto_rawDescOnce.Do(func() {
-		file_jwk_proto_rawDescData = protoimpl.X.CompressGZIP(unsafe.Slice(unsafe.StringData(file_jwk_proto_rawDesc), len(file_jwk_proto_rawDesc)))
+func file_anovel_jsonkeys_v2_jwk_proto_rawDescGZIP() []byte {
+	file_anovel_jsonkeys_v2_jwk_proto_rawDescOnce.Do(func() {
+		file_anovel_jsonkeys_v2_jwk_proto_rawDescData = protoimpl.X.CompressGZIP(unsafe.Slice(unsafe.StringData(file_anovel_jsonkeys_v2_jwk_proto_rawDesc), len(file_anovel_jsonkeys_v2_jwk_proto_rawDesc)))
 	})
-	return file_jwk_proto_rawDescData
+	return file_anovel_jsonkeys_v2_jwk_proto_rawDescData
 }
 
-var file_jwk_proto_msgTypes = make([]protoimpl.MessageInfo, 1)
-var file_jwk_proto_goTypes = []any{
-	(*Jwk)(nil), // 0: Jwk
+var file_anovel_jsonkeys_v2_jwk_proto_msgTypes = make([]protoimpl.MessageInfo, 1)
+var file_anovel_jsonkeys_v2_jwk_proto_goTypes = []any{
+	(*Jwk)(nil), // 0: anovel.jsonkeys.v2.Jwk
 }
-var file_jwk_proto_depIdxs = []int32{
+var file_anovel_jsonkeys_v2_jwk_proto_depIdxs = []int32{
 	0, // [0:0] is the sub-list for method output_type
 	0, // [0:0] is the sub-list for method input_type
 	0, // [0:0] is the sub-list for extension type_name
@@ -154,26 +155,26 @@ var file_jwk_proto_depIdxs = []int32{
 	0, // [0:0] is the sub-list for field type_name
 }
 
-func init() { file_jwk_proto_init() }
-func file_jwk_proto_init() {
-	if File_jwk_proto != nil {
+func init() { file_anovel_jsonkeys_v2_jwk_proto_init() }
+func file_anovel_jsonkeys_v2_jwk_proto_init() {
+	if File_anovel_jsonkeys_v2_jwk_proto != nil {
 		return
 	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
-			RawDescriptor: unsafe.Slice(unsafe.StringData(file_jwk_proto_rawDesc), len(file_jwk_proto_rawDesc)),
+			RawDescriptor: unsafe.Slice(unsafe.StringData(file_anovel_jsonkeys_v2_jwk_proto_rawDesc), len(file_anovel_jsonkeys_v2_jwk_proto_rawDesc)),
 			NumEnums:      0,
 			NumMessages:   1,
 			NumExtensions: 0,
 			NumServices:   0,
 		},
-		GoTypes:           file_jwk_proto_goTypes,
-		DependencyIndexes: file_jwk_proto_depIdxs,
-		MessageInfos:      file_jwk_proto_msgTypes,
+		GoTypes:           file_anovel_jsonkeys_v2_jwk_proto_goTypes,
+		DependencyIndexes: file_anovel_jsonkeys_v2_jwk_proto_depIdxs,
+		MessageInfos:      file_anovel_jsonkeys_v2_jwk_proto_msgTypes,
 	}.Build()
-	File_jwk_proto = out.File
-	file_jwk_proto_goTypes = nil
-	file_jwk_proto_depIdxs = nil
+	File_anovel_jsonkeys_v2_jwk_proto = out.File
+	file_anovel_jsonkeys_v2_jwk_proto_goTypes = nil
+	file_anovel_jsonkeys_v2_jwk_proto_depIdxs = nil
 }

--- a/internal/handlers/protogen/anovel/jsonkeys/v2/jwk_get.pb.go
+++ b/internal/handlers/protogen/anovel/jsonkeys/v2/jwk_get.pb.go
@@ -2,9 +2,9 @@
 // versions:
 // 	protoc-gen-go v1.36.11
 // 	protoc        (unknown)
-// source: jwk_get.proto
+// source: anovel/jsonkeys/v2/jwk_get.proto
 
-package protogen
+package jsonkeysv2
 
 import (
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
@@ -32,7 +32,7 @@ type JwkGetRequest struct {
 
 func (x *JwkGetRequest) Reset() {
 	*x = JwkGetRequest{}
-	mi := &file_jwk_get_proto_msgTypes[0]
+	mi := &file_anovel_jsonkeys_v2_jwk_get_proto_msgTypes[0]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -44,7 +44,7 @@ func (x *JwkGetRequest) String() string {
 func (*JwkGetRequest) ProtoMessage() {}
 
 func (x *JwkGetRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_jwk_get_proto_msgTypes[0]
+	mi := &file_anovel_jsonkeys_v2_jwk_get_proto_msgTypes[0]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -57,7 +57,7 @@ func (x *JwkGetRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use JwkGetRequest.ProtoReflect.Descriptor instead.
 func (*JwkGetRequest) Descriptor() ([]byte, []int) {
-	return file_jwk_get_proto_rawDescGZIP(), []int{0}
+	return file_anovel_jsonkeys_v2_jwk_get_proto_rawDescGZIP(), []int{0}
 }
 
 func (x *JwkGetRequest) GetId() string {
@@ -78,7 +78,7 @@ type JwkGetResponse struct {
 
 func (x *JwkGetResponse) Reset() {
 	*x = JwkGetResponse{}
-	mi := &file_jwk_get_proto_msgTypes[1]
+	mi := &file_anovel_jsonkeys_v2_jwk_get_proto_msgTypes[1]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -90,7 +90,7 @@ func (x *JwkGetResponse) String() string {
 func (*JwkGetResponse) ProtoMessage() {}
 
 func (x *JwkGetResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_jwk_get_proto_msgTypes[1]
+	mi := &file_anovel_jsonkeys_v2_jwk_get_proto_msgTypes[1]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -103,7 +103,7 @@ func (x *JwkGetResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use JwkGetResponse.ProtoReflect.Descriptor instead.
 func (*JwkGetResponse) Descriptor() ([]byte, []int) {
-	return file_jwk_get_proto_rawDescGZIP(), []int{1}
+	return file_anovel_jsonkeys_v2_jwk_get_proto_rawDescGZIP(), []int{1}
 }
 
 func (x *JwkGetResponse) GetJwk() *Jwk {
@@ -113,40 +113,41 @@ func (x *JwkGetResponse) GetJwk() *Jwk {
 	return nil
 }
 
-var File_jwk_get_proto protoreflect.FileDescriptor
+var File_anovel_jsonkeys_v2_jwk_get_proto protoreflect.FileDescriptor
 
-const file_jwk_get_proto_rawDesc = "" +
+const file_anovel_jsonkeys_v2_jwk_get_proto_rawDesc = "" +
 	"\n" +
-	"\rjwk_get.proto\x1a\tjwk.proto\"\x1f\n" +
+	" anovel/jsonkeys/v2/jwk_get.proto\x12\x12anovel.jsonkeys.v2\x1a\x1canovel/jsonkeys/v2/jwk.proto\"\x1f\n" +
 	"\rJwkGetRequest\x12\x0e\n" +
-	"\x02id\x18\x01 \x01(\tR\x02id\"(\n" +
-	"\x0eJwkGetResponse\x12\x16\n" +
-	"\x03jwk\x18\x01 \x01(\v2\x04.JwkR\x03jwk2:\n" +
-	"\rJwkGetService\x12)\n" +
-	"\x06JwkGet\x12\x0e.JwkGetRequest\x1a\x0f.JwkGetResponseB\\B\vJwkGetProtoP\x01ZKgithub.com/a-novel/service-json-keys/v2/internal/handlers/protogen;protogenb\x06proto3"
+	"\x02id\x18\x01 \x01(\tR\x02id\";\n" +
+	"\x0eJwkGetResponse\x12)\n" +
+	"\x03jwk\x18\x01 \x01(\v2\x17.anovel.jsonkeys.v2.JwkR\x03jwk2`\n" +
+	"\rJwkGetService\x12O\n" +
+	"\x06JwkGet\x12!.anovel.jsonkeys.v2.JwkGetRequest\x1a\".anovel.jsonkeys.v2.JwkGetResponseB\xf1\x01\n" +
+	"\x16com.anovel.jsonkeys.v2B\vJwkGetProtoP\x01Z`github.com/a-novel/service-json-keys/v2/internal/handlers/protogen/anovel/jsonkeys/v2;jsonkeysv2\xa2\x02\x03AJX\xaa\x02\x12Anovel.Jsonkeys.V2\xca\x02\x12Anovel\\Jsonkeys\\V2\xe2\x02\x1eAnovel\\Jsonkeys\\V2\\GPBMetadata\xea\x02\x14Anovel::Jsonkeys::V2b\x06proto3"
 
 var (
-	file_jwk_get_proto_rawDescOnce sync.Once
-	file_jwk_get_proto_rawDescData []byte
+	file_anovel_jsonkeys_v2_jwk_get_proto_rawDescOnce sync.Once
+	file_anovel_jsonkeys_v2_jwk_get_proto_rawDescData []byte
 )
 
-func file_jwk_get_proto_rawDescGZIP() []byte {
-	file_jwk_get_proto_rawDescOnce.Do(func() {
-		file_jwk_get_proto_rawDescData = protoimpl.X.CompressGZIP(unsafe.Slice(unsafe.StringData(file_jwk_get_proto_rawDesc), len(file_jwk_get_proto_rawDesc)))
+func file_anovel_jsonkeys_v2_jwk_get_proto_rawDescGZIP() []byte {
+	file_anovel_jsonkeys_v2_jwk_get_proto_rawDescOnce.Do(func() {
+		file_anovel_jsonkeys_v2_jwk_get_proto_rawDescData = protoimpl.X.CompressGZIP(unsafe.Slice(unsafe.StringData(file_anovel_jsonkeys_v2_jwk_get_proto_rawDesc), len(file_anovel_jsonkeys_v2_jwk_get_proto_rawDesc)))
 	})
-	return file_jwk_get_proto_rawDescData
+	return file_anovel_jsonkeys_v2_jwk_get_proto_rawDescData
 }
 
-var file_jwk_get_proto_msgTypes = make([]protoimpl.MessageInfo, 2)
-var file_jwk_get_proto_goTypes = []any{
-	(*JwkGetRequest)(nil),  // 0: JwkGetRequest
-	(*JwkGetResponse)(nil), // 1: JwkGetResponse
-	(*Jwk)(nil),            // 2: Jwk
+var file_anovel_jsonkeys_v2_jwk_get_proto_msgTypes = make([]protoimpl.MessageInfo, 2)
+var file_anovel_jsonkeys_v2_jwk_get_proto_goTypes = []any{
+	(*JwkGetRequest)(nil),  // 0: anovel.jsonkeys.v2.JwkGetRequest
+	(*JwkGetResponse)(nil), // 1: anovel.jsonkeys.v2.JwkGetResponse
+	(*Jwk)(nil),            // 2: anovel.jsonkeys.v2.Jwk
 }
-var file_jwk_get_proto_depIdxs = []int32{
-	2, // 0: JwkGetResponse.jwk:type_name -> Jwk
-	0, // 1: JwkGetService.JwkGet:input_type -> JwkGetRequest
-	1, // 2: JwkGetService.JwkGet:output_type -> JwkGetResponse
+var file_anovel_jsonkeys_v2_jwk_get_proto_depIdxs = []int32{
+	2, // 0: anovel.jsonkeys.v2.JwkGetResponse.jwk:type_name -> anovel.jsonkeys.v2.Jwk
+	0, // 1: anovel.jsonkeys.v2.JwkGetService.JwkGet:input_type -> anovel.jsonkeys.v2.JwkGetRequest
+	1, // 2: anovel.jsonkeys.v2.JwkGetService.JwkGet:output_type -> anovel.jsonkeys.v2.JwkGetResponse
 	2, // [2:3] is the sub-list for method output_type
 	1, // [1:2] is the sub-list for method input_type
 	1, // [1:1] is the sub-list for extension type_name
@@ -154,27 +155,27 @@ var file_jwk_get_proto_depIdxs = []int32{
 	0, // [0:1] is the sub-list for field type_name
 }
 
-func init() { file_jwk_get_proto_init() }
-func file_jwk_get_proto_init() {
-	if File_jwk_get_proto != nil {
+func init() { file_anovel_jsonkeys_v2_jwk_get_proto_init() }
+func file_anovel_jsonkeys_v2_jwk_get_proto_init() {
+	if File_anovel_jsonkeys_v2_jwk_get_proto != nil {
 		return
 	}
-	file_jwk_proto_init()
+	file_anovel_jsonkeys_v2_jwk_proto_init()
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
-			RawDescriptor: unsafe.Slice(unsafe.StringData(file_jwk_get_proto_rawDesc), len(file_jwk_get_proto_rawDesc)),
+			RawDescriptor: unsafe.Slice(unsafe.StringData(file_anovel_jsonkeys_v2_jwk_get_proto_rawDesc), len(file_anovel_jsonkeys_v2_jwk_get_proto_rawDesc)),
 			NumEnums:      0,
 			NumMessages:   2,
 			NumExtensions: 0,
 			NumServices:   1,
 		},
-		GoTypes:           file_jwk_get_proto_goTypes,
-		DependencyIndexes: file_jwk_get_proto_depIdxs,
-		MessageInfos:      file_jwk_get_proto_msgTypes,
+		GoTypes:           file_anovel_jsonkeys_v2_jwk_get_proto_goTypes,
+		DependencyIndexes: file_anovel_jsonkeys_v2_jwk_get_proto_depIdxs,
+		MessageInfos:      file_anovel_jsonkeys_v2_jwk_get_proto_msgTypes,
 	}.Build()
-	File_jwk_get_proto = out.File
-	file_jwk_get_proto_goTypes = nil
-	file_jwk_get_proto_depIdxs = nil
+	File_anovel_jsonkeys_v2_jwk_get_proto = out.File
+	file_anovel_jsonkeys_v2_jwk_get_proto_goTypes = nil
+	file_anovel_jsonkeys_v2_jwk_get_proto_depIdxs = nil
 }

--- a/internal/handlers/protogen/anovel/jsonkeys/v2/jwk_get_grpc.pb.go
+++ b/internal/handlers/protogen/anovel/jsonkeys/v2/jwk_get_grpc.pb.go
@@ -2,9 +2,9 @@
 // versions:
 // - protoc-gen-go-grpc v1.6.2
 // - protoc             (unknown)
-// source: jwk_get.proto
+// source: anovel/jsonkeys/v2/jwk_get.proto
 
-package protogen
+package jsonkeysv2
 
 import (
 	context "context"
@@ -19,7 +19,7 @@ import (
 const _ = grpc.SupportPackageIsVersion9
 
 const (
-	JwkGetService_JwkGet_FullMethodName = "/JwkGetService/JwkGet"
+	JwkGetService_JwkGet_FullMethodName = "/anovel.jsonkeys.v2.JwkGetService/JwkGet"
 )
 
 // JwkGetServiceClient is the client API for JwkGetService service.
@@ -118,7 +118,7 @@ func _JwkGetService_JwkGet_Handler(srv interface{}, ctx context.Context, dec fun
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
 var JwkGetService_ServiceDesc = grpc.ServiceDesc{
-	ServiceName: "JwkGetService",
+	ServiceName: "anovel.jsonkeys.v2.JwkGetService",
 	HandlerType: (*JwkGetServiceServer)(nil),
 	Methods: []grpc.MethodDesc{
 		{
@@ -127,5 +127,5 @@ var JwkGetService_ServiceDesc = grpc.ServiceDesc{
 		},
 	},
 	Streams:  []grpc.StreamDesc{},
-	Metadata: "jwk_get.proto",
+	Metadata: "anovel/jsonkeys/v2/jwk_get.proto",
 }

--- a/internal/handlers/protogen/anovel/jsonkeys/v2/jwk_list.pb.go
+++ b/internal/handlers/protogen/anovel/jsonkeys/v2/jwk_list.pb.go
@@ -2,9 +2,9 @@
 // versions:
 // 	protoc-gen-go v1.36.11
 // 	protoc        (unknown)
-// source: jwk_list.proto
+// source: anovel/jsonkeys/v2/jwk_list.proto
 
-package protogen
+package jsonkeysv2
 
 import (
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
@@ -32,7 +32,7 @@ type JwkListRequest struct {
 
 func (x *JwkListRequest) Reset() {
 	*x = JwkListRequest{}
-	mi := &file_jwk_list_proto_msgTypes[0]
+	mi := &file_anovel_jsonkeys_v2_jwk_list_proto_msgTypes[0]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -44,7 +44,7 @@ func (x *JwkListRequest) String() string {
 func (*JwkListRequest) ProtoMessage() {}
 
 func (x *JwkListRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_jwk_list_proto_msgTypes[0]
+	mi := &file_anovel_jsonkeys_v2_jwk_list_proto_msgTypes[0]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -57,7 +57,7 @@ func (x *JwkListRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use JwkListRequest.ProtoReflect.Descriptor instead.
 func (*JwkListRequest) Descriptor() ([]byte, []int) {
-	return file_jwk_list_proto_rawDescGZIP(), []int{0}
+	return file_anovel_jsonkeys_v2_jwk_list_proto_rawDescGZIP(), []int{0}
 }
 
 func (x *JwkListRequest) GetUsage() string {
@@ -78,7 +78,7 @@ type JwkListResponse struct {
 
 func (x *JwkListResponse) Reset() {
 	*x = JwkListResponse{}
-	mi := &file_jwk_list_proto_msgTypes[1]
+	mi := &file_anovel_jsonkeys_v2_jwk_list_proto_msgTypes[1]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -90,7 +90,7 @@ func (x *JwkListResponse) String() string {
 func (*JwkListResponse) ProtoMessage() {}
 
 func (x *JwkListResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_jwk_list_proto_msgTypes[1]
+	mi := &file_anovel_jsonkeys_v2_jwk_list_proto_msgTypes[1]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -103,7 +103,7 @@ func (x *JwkListResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use JwkListResponse.ProtoReflect.Descriptor instead.
 func (*JwkListResponse) Descriptor() ([]byte, []int) {
-	return file_jwk_list_proto_rawDescGZIP(), []int{1}
+	return file_anovel_jsonkeys_v2_jwk_list_proto_rawDescGZIP(), []int{1}
 }
 
 func (x *JwkListResponse) GetKeys() []*Jwk {
@@ -113,40 +113,41 @@ func (x *JwkListResponse) GetKeys() []*Jwk {
 	return nil
 }
 
-var File_jwk_list_proto protoreflect.FileDescriptor
+var File_anovel_jsonkeys_v2_jwk_list_proto protoreflect.FileDescriptor
 
-const file_jwk_list_proto_rawDesc = "" +
+const file_anovel_jsonkeys_v2_jwk_list_proto_rawDesc = "" +
 	"\n" +
-	"\x0ejwk_list.proto\x1a\tjwk.proto\"&\n" +
+	"!anovel/jsonkeys/v2/jwk_list.proto\x12\x12anovel.jsonkeys.v2\x1a\x1canovel/jsonkeys/v2/jwk.proto\"&\n" +
 	"\x0eJwkListRequest\x12\x14\n" +
-	"\x05usage\x18\x01 \x01(\tR\x05usage\"+\n" +
-	"\x0fJwkListResponse\x12\x18\n" +
-	"\x04keys\x18\x01 \x03(\v2\x04.JwkR\x04keys2>\n" +
-	"\x0eJwkListService\x12,\n" +
-	"\aJwkList\x12\x0f.JwkListRequest\x1a\x10.JwkListResponseB]B\fJwkListProtoP\x01ZKgithub.com/a-novel/service-json-keys/v2/internal/handlers/protogen;protogenb\x06proto3"
+	"\x05usage\x18\x01 \x01(\tR\x05usage\">\n" +
+	"\x0fJwkListResponse\x12+\n" +
+	"\x04keys\x18\x01 \x03(\v2\x17.anovel.jsonkeys.v2.JwkR\x04keys2d\n" +
+	"\x0eJwkListService\x12R\n" +
+	"\aJwkList\x12\".anovel.jsonkeys.v2.JwkListRequest\x1a#.anovel.jsonkeys.v2.JwkListResponseB\xf2\x01\n" +
+	"\x16com.anovel.jsonkeys.v2B\fJwkListProtoP\x01Z`github.com/a-novel/service-json-keys/v2/internal/handlers/protogen/anovel/jsonkeys/v2;jsonkeysv2\xa2\x02\x03AJX\xaa\x02\x12Anovel.Jsonkeys.V2\xca\x02\x12Anovel\\Jsonkeys\\V2\xe2\x02\x1eAnovel\\Jsonkeys\\V2\\GPBMetadata\xea\x02\x14Anovel::Jsonkeys::V2b\x06proto3"
 
 var (
-	file_jwk_list_proto_rawDescOnce sync.Once
-	file_jwk_list_proto_rawDescData []byte
+	file_anovel_jsonkeys_v2_jwk_list_proto_rawDescOnce sync.Once
+	file_anovel_jsonkeys_v2_jwk_list_proto_rawDescData []byte
 )
 
-func file_jwk_list_proto_rawDescGZIP() []byte {
-	file_jwk_list_proto_rawDescOnce.Do(func() {
-		file_jwk_list_proto_rawDescData = protoimpl.X.CompressGZIP(unsafe.Slice(unsafe.StringData(file_jwk_list_proto_rawDesc), len(file_jwk_list_proto_rawDesc)))
+func file_anovel_jsonkeys_v2_jwk_list_proto_rawDescGZIP() []byte {
+	file_anovel_jsonkeys_v2_jwk_list_proto_rawDescOnce.Do(func() {
+		file_anovel_jsonkeys_v2_jwk_list_proto_rawDescData = protoimpl.X.CompressGZIP(unsafe.Slice(unsafe.StringData(file_anovel_jsonkeys_v2_jwk_list_proto_rawDesc), len(file_anovel_jsonkeys_v2_jwk_list_proto_rawDesc)))
 	})
-	return file_jwk_list_proto_rawDescData
+	return file_anovel_jsonkeys_v2_jwk_list_proto_rawDescData
 }
 
-var file_jwk_list_proto_msgTypes = make([]protoimpl.MessageInfo, 2)
-var file_jwk_list_proto_goTypes = []any{
-	(*JwkListRequest)(nil),  // 0: JwkListRequest
-	(*JwkListResponse)(nil), // 1: JwkListResponse
-	(*Jwk)(nil),             // 2: Jwk
+var file_anovel_jsonkeys_v2_jwk_list_proto_msgTypes = make([]protoimpl.MessageInfo, 2)
+var file_anovel_jsonkeys_v2_jwk_list_proto_goTypes = []any{
+	(*JwkListRequest)(nil),  // 0: anovel.jsonkeys.v2.JwkListRequest
+	(*JwkListResponse)(nil), // 1: anovel.jsonkeys.v2.JwkListResponse
+	(*Jwk)(nil),             // 2: anovel.jsonkeys.v2.Jwk
 }
-var file_jwk_list_proto_depIdxs = []int32{
-	2, // 0: JwkListResponse.keys:type_name -> Jwk
-	0, // 1: JwkListService.JwkList:input_type -> JwkListRequest
-	1, // 2: JwkListService.JwkList:output_type -> JwkListResponse
+var file_anovel_jsonkeys_v2_jwk_list_proto_depIdxs = []int32{
+	2, // 0: anovel.jsonkeys.v2.JwkListResponse.keys:type_name -> anovel.jsonkeys.v2.Jwk
+	0, // 1: anovel.jsonkeys.v2.JwkListService.JwkList:input_type -> anovel.jsonkeys.v2.JwkListRequest
+	1, // 2: anovel.jsonkeys.v2.JwkListService.JwkList:output_type -> anovel.jsonkeys.v2.JwkListResponse
 	2, // [2:3] is the sub-list for method output_type
 	1, // [1:2] is the sub-list for method input_type
 	1, // [1:1] is the sub-list for extension type_name
@@ -154,27 +155,27 @@ var file_jwk_list_proto_depIdxs = []int32{
 	0, // [0:1] is the sub-list for field type_name
 }
 
-func init() { file_jwk_list_proto_init() }
-func file_jwk_list_proto_init() {
-	if File_jwk_list_proto != nil {
+func init() { file_anovel_jsonkeys_v2_jwk_list_proto_init() }
+func file_anovel_jsonkeys_v2_jwk_list_proto_init() {
+	if File_anovel_jsonkeys_v2_jwk_list_proto != nil {
 		return
 	}
-	file_jwk_proto_init()
+	file_anovel_jsonkeys_v2_jwk_proto_init()
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
-			RawDescriptor: unsafe.Slice(unsafe.StringData(file_jwk_list_proto_rawDesc), len(file_jwk_list_proto_rawDesc)),
+			RawDescriptor: unsafe.Slice(unsafe.StringData(file_anovel_jsonkeys_v2_jwk_list_proto_rawDesc), len(file_anovel_jsonkeys_v2_jwk_list_proto_rawDesc)),
 			NumEnums:      0,
 			NumMessages:   2,
 			NumExtensions: 0,
 			NumServices:   1,
 		},
-		GoTypes:           file_jwk_list_proto_goTypes,
-		DependencyIndexes: file_jwk_list_proto_depIdxs,
-		MessageInfos:      file_jwk_list_proto_msgTypes,
+		GoTypes:           file_anovel_jsonkeys_v2_jwk_list_proto_goTypes,
+		DependencyIndexes: file_anovel_jsonkeys_v2_jwk_list_proto_depIdxs,
+		MessageInfos:      file_anovel_jsonkeys_v2_jwk_list_proto_msgTypes,
 	}.Build()
-	File_jwk_list_proto = out.File
-	file_jwk_list_proto_goTypes = nil
-	file_jwk_list_proto_depIdxs = nil
+	File_anovel_jsonkeys_v2_jwk_list_proto = out.File
+	file_anovel_jsonkeys_v2_jwk_list_proto_goTypes = nil
+	file_anovel_jsonkeys_v2_jwk_list_proto_depIdxs = nil
 }

--- a/internal/handlers/protogen/anovel/jsonkeys/v2/jwk_list_grpc.pb.go
+++ b/internal/handlers/protogen/anovel/jsonkeys/v2/jwk_list_grpc.pb.go
@@ -2,9 +2,9 @@
 // versions:
 // - protoc-gen-go-grpc v1.6.2
 // - protoc             (unknown)
-// source: jwk_list.proto
+// source: anovel/jsonkeys/v2/jwk_list.proto
 
-package protogen
+package jsonkeysv2
 
 import (
 	context "context"
@@ -19,7 +19,7 @@ import (
 const _ = grpc.SupportPackageIsVersion9
 
 const (
-	JwkListService_JwkList_FullMethodName = "/JwkListService/JwkList"
+	JwkListService_JwkList_FullMethodName = "/anovel.jsonkeys.v2.JwkListService/JwkList"
 )
 
 // JwkListServiceClient is the client API for JwkListService service.
@@ -118,7 +118,7 @@ func _JwkListService_JwkList_Handler(srv interface{}, ctx context.Context, dec f
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
 var JwkListService_ServiceDesc = grpc.ServiceDesc{
-	ServiceName: "JwkListService",
+	ServiceName: "anovel.jsonkeys.v2.JwkListService",
 	HandlerType: (*JwkListServiceServer)(nil),
 	Methods: []grpc.MethodDesc{
 		{
@@ -127,5 +127,5 @@ var JwkListService_ServiceDesc = grpc.ServiceDesc{
 		},
 	},
 	Streams:  []grpc.StreamDesc{},
-	Metadata: "jwk_list.proto",
+	Metadata: "anovel/jsonkeys/v2/jwk_list.proto",
 }

--- a/internal/handlers/protogen/anovel/jsonkeys/v2/status.pb.go
+++ b/internal/handlers/protogen/anovel/jsonkeys/v2/status.pb.go
@@ -2,9 +2,9 @@
 // versions:
 // 	protoc-gen-go v1.36.11
 // 	protoc        (unknown)
-// source: status.proto
+// source: anovel/jsonkeys/v2/status.proto
 
-package protogen
+package jsonkeysv2
 
 import (
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
@@ -61,11 +61,11 @@ func (x DependencyStatus) String() string {
 }
 
 func (DependencyStatus) Descriptor() protoreflect.EnumDescriptor {
-	return file_status_proto_enumTypes[0].Descriptor()
+	return file_anovel_jsonkeys_v2_status_proto_enumTypes[0].Descriptor()
 }
 
 func (DependencyStatus) Type() protoreflect.EnumType {
-	return &file_status_proto_enumTypes[0]
+	return &file_anovel_jsonkeys_v2_status_proto_enumTypes[0]
 }
 
 func (x DependencyStatus) Number() protoreflect.EnumNumber {
@@ -74,7 +74,7 @@ func (x DependencyStatus) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use DependencyStatus.Descriptor instead.
 func (DependencyStatus) EnumDescriptor() ([]byte, []int) {
-	return file_status_proto_rawDescGZIP(), []int{0}
+	return file_anovel_jsonkeys_v2_status_proto_rawDescGZIP(), []int{0}
 }
 
 // DependencyHealth reports the health of a single external dependency.
@@ -85,14 +85,14 @@ func (DependencyStatus) EnumDescriptor() ([]byte, []int) {
 type DependencyHealth struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// The dependency's current operational status.
-	Status        DependencyStatus `protobuf:"varint,1,opt,name=status,proto3,enum=DependencyStatus" json:"status,omitempty"`
+	Status        DependencyStatus `protobuf:"varint,1,opt,name=status,proto3,enum=anovel.jsonkeys.v2.DependencyStatus" json:"status,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *DependencyHealth) Reset() {
 	*x = DependencyHealth{}
-	mi := &file_status_proto_msgTypes[0]
+	mi := &file_anovel_jsonkeys_v2_status_proto_msgTypes[0]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -104,7 +104,7 @@ func (x *DependencyHealth) String() string {
 func (*DependencyHealth) ProtoMessage() {}
 
 func (x *DependencyHealth) ProtoReflect() protoreflect.Message {
-	mi := &file_status_proto_msgTypes[0]
+	mi := &file_anovel_jsonkeys_v2_status_proto_msgTypes[0]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -117,7 +117,7 @@ func (x *DependencyHealth) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DependencyHealth.ProtoReflect.Descriptor instead.
 func (*DependencyHealth) Descriptor() ([]byte, []int) {
-	return file_status_proto_rawDescGZIP(), []int{0}
+	return file_anovel_jsonkeys_v2_status_proto_rawDescGZIP(), []int{0}
 }
 
 func (x *DependencyHealth) GetStatus() DependencyStatus {
@@ -136,7 +136,7 @@ type StatusRequest struct {
 
 func (x *StatusRequest) Reset() {
 	*x = StatusRequest{}
-	mi := &file_status_proto_msgTypes[1]
+	mi := &file_anovel_jsonkeys_v2_status_proto_msgTypes[1]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -148,7 +148,7 @@ func (x *StatusRequest) String() string {
 func (*StatusRequest) ProtoMessage() {}
 
 func (x *StatusRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_status_proto_msgTypes[1]
+	mi := &file_anovel_jsonkeys_v2_status_proto_msgTypes[1]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -161,7 +161,7 @@ func (x *StatusRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StatusRequest.ProtoReflect.Descriptor instead.
 func (*StatusRequest) Descriptor() ([]byte, []int) {
-	return file_status_proto_rawDescGZIP(), []int{1}
+	return file_anovel_jsonkeys_v2_status_proto_rawDescGZIP(), []int{1}
 }
 
 // StatusResponse reports the health of all service dependencies checked at request time.
@@ -175,7 +175,7 @@ type StatusResponse struct {
 
 func (x *StatusResponse) Reset() {
 	*x = StatusResponse{}
-	mi := &file_status_proto_msgTypes[2]
+	mi := &file_anovel_jsonkeys_v2_status_proto_msgTypes[2]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -187,7 +187,7 @@ func (x *StatusResponse) String() string {
 func (*StatusResponse) ProtoMessage() {}
 
 func (x *StatusResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_status_proto_msgTypes[2]
+	mi := &file_anovel_jsonkeys_v2_status_proto_msgTypes[2]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -200,7 +200,7 @@ func (x *StatusResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StatusResponse.ProtoReflect.Descriptor instead.
 func (*StatusResponse) Descriptor() ([]byte, []int) {
-	return file_status_proto_rawDescGZIP(), []int{2}
+	return file_anovel_jsonkeys_v2_status_proto_rawDescGZIP(), []int{2}
 }
 
 func (x *StatusResponse) GetPostgres() *DependencyHealth {
@@ -210,48 +210,49 @@ func (x *StatusResponse) GetPostgres() *DependencyHealth {
 	return nil
 }
 
-var File_status_proto protoreflect.FileDescriptor
+var File_anovel_jsonkeys_v2_status_proto protoreflect.FileDescriptor
 
-const file_status_proto_rawDesc = "" +
+const file_anovel_jsonkeys_v2_status_proto_rawDesc = "" +
 	"\n" +
-	"\fstatus.proto\"H\n" +
-	"\x10DependencyHealth\x12)\n" +
-	"\x06status\x18\x01 \x01(\x0e2\x11.DependencyStatusR\x06statusJ\x04\b\x02\x10\x03R\x03err\"\x0f\n" +
-	"\rStatusRequest\"?\n" +
-	"\x0eStatusResponse\x12-\n" +
-	"\bpostgres\x18\x01 \x01(\v2\x11.DependencyHealthR\bpostgres*k\n" +
+	"\x1fanovel/jsonkeys/v2/status.proto\x12\x12anovel.jsonkeys.v2\"[\n" +
+	"\x10DependencyHealth\x12<\n" +
+	"\x06status\x18\x01 \x01(\x0e2$.anovel.jsonkeys.v2.DependencyStatusR\x06statusJ\x04\b\x02\x10\x03R\x03err\"\x0f\n" +
+	"\rStatusRequest\"R\n" +
+	"\x0eStatusResponse\x12@\n" +
+	"\bpostgres\x18\x01 \x01(\v2$.anovel.jsonkeys.v2.DependencyHealthR\bpostgres*k\n" +
 	"\x10DependencyStatus\x12!\n" +
 	"\x1dDEPENDENCY_STATUS_UNSPECIFIED\x10\x00\x12\x18\n" +
 	"\x14DEPENDENCY_STATUS_UP\x10\x01\x12\x1a\n" +
-	"\x16DEPENDENCY_STATUS_DOWN\x10\x022:\n" +
-	"\rStatusService\x12)\n" +
-	"\x06Status\x12\x0e.StatusRequest\x1a\x0f.StatusResponseB\\B\vStatusProtoP\x01ZKgithub.com/a-novel/service-json-keys/v2/internal/handlers/protogen;protogenb\x06proto3"
+	"\x16DEPENDENCY_STATUS_DOWN\x10\x022`\n" +
+	"\rStatusService\x12O\n" +
+	"\x06Status\x12!.anovel.jsonkeys.v2.StatusRequest\x1a\".anovel.jsonkeys.v2.StatusResponseB\xf1\x01\n" +
+	"\x16com.anovel.jsonkeys.v2B\vStatusProtoP\x01Z`github.com/a-novel/service-json-keys/v2/internal/handlers/protogen/anovel/jsonkeys/v2;jsonkeysv2\xa2\x02\x03AJX\xaa\x02\x12Anovel.Jsonkeys.V2\xca\x02\x12Anovel\\Jsonkeys\\V2\xe2\x02\x1eAnovel\\Jsonkeys\\V2\\GPBMetadata\xea\x02\x14Anovel::Jsonkeys::V2b\x06proto3"
 
 var (
-	file_status_proto_rawDescOnce sync.Once
-	file_status_proto_rawDescData []byte
+	file_anovel_jsonkeys_v2_status_proto_rawDescOnce sync.Once
+	file_anovel_jsonkeys_v2_status_proto_rawDescData []byte
 )
 
-func file_status_proto_rawDescGZIP() []byte {
-	file_status_proto_rawDescOnce.Do(func() {
-		file_status_proto_rawDescData = protoimpl.X.CompressGZIP(unsafe.Slice(unsafe.StringData(file_status_proto_rawDesc), len(file_status_proto_rawDesc)))
+func file_anovel_jsonkeys_v2_status_proto_rawDescGZIP() []byte {
+	file_anovel_jsonkeys_v2_status_proto_rawDescOnce.Do(func() {
+		file_anovel_jsonkeys_v2_status_proto_rawDescData = protoimpl.X.CompressGZIP(unsafe.Slice(unsafe.StringData(file_anovel_jsonkeys_v2_status_proto_rawDesc), len(file_anovel_jsonkeys_v2_status_proto_rawDesc)))
 	})
-	return file_status_proto_rawDescData
+	return file_anovel_jsonkeys_v2_status_proto_rawDescData
 }
 
-var file_status_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_status_proto_msgTypes = make([]protoimpl.MessageInfo, 3)
-var file_status_proto_goTypes = []any{
-	(DependencyStatus)(0),    // 0: DependencyStatus
-	(*DependencyHealth)(nil), // 1: DependencyHealth
-	(*StatusRequest)(nil),    // 2: StatusRequest
-	(*StatusResponse)(nil),   // 3: StatusResponse
+var file_anovel_jsonkeys_v2_status_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
+var file_anovel_jsonkeys_v2_status_proto_msgTypes = make([]protoimpl.MessageInfo, 3)
+var file_anovel_jsonkeys_v2_status_proto_goTypes = []any{
+	(DependencyStatus)(0),    // 0: anovel.jsonkeys.v2.DependencyStatus
+	(*DependencyHealth)(nil), // 1: anovel.jsonkeys.v2.DependencyHealth
+	(*StatusRequest)(nil),    // 2: anovel.jsonkeys.v2.StatusRequest
+	(*StatusResponse)(nil),   // 3: anovel.jsonkeys.v2.StatusResponse
 }
-var file_status_proto_depIdxs = []int32{
-	0, // 0: DependencyHealth.status:type_name -> DependencyStatus
-	1, // 1: StatusResponse.postgres:type_name -> DependencyHealth
-	2, // 2: StatusService.Status:input_type -> StatusRequest
-	3, // 3: StatusService.Status:output_type -> StatusResponse
+var file_anovel_jsonkeys_v2_status_proto_depIdxs = []int32{
+	0, // 0: anovel.jsonkeys.v2.DependencyHealth.status:type_name -> anovel.jsonkeys.v2.DependencyStatus
+	1, // 1: anovel.jsonkeys.v2.StatusResponse.postgres:type_name -> anovel.jsonkeys.v2.DependencyHealth
+	2, // 2: anovel.jsonkeys.v2.StatusService.Status:input_type -> anovel.jsonkeys.v2.StatusRequest
+	3, // 3: anovel.jsonkeys.v2.StatusService.Status:output_type -> anovel.jsonkeys.v2.StatusResponse
 	3, // [3:4] is the sub-list for method output_type
 	2, // [2:3] is the sub-list for method input_type
 	2, // [2:2] is the sub-list for extension type_name
@@ -259,27 +260,27 @@ var file_status_proto_depIdxs = []int32{
 	0, // [0:2] is the sub-list for field type_name
 }
 
-func init() { file_status_proto_init() }
-func file_status_proto_init() {
-	if File_status_proto != nil {
+func init() { file_anovel_jsonkeys_v2_status_proto_init() }
+func file_anovel_jsonkeys_v2_status_proto_init() {
+	if File_anovel_jsonkeys_v2_status_proto != nil {
 		return
 	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
-			RawDescriptor: unsafe.Slice(unsafe.StringData(file_status_proto_rawDesc), len(file_status_proto_rawDesc)),
+			RawDescriptor: unsafe.Slice(unsafe.StringData(file_anovel_jsonkeys_v2_status_proto_rawDesc), len(file_anovel_jsonkeys_v2_status_proto_rawDesc)),
 			NumEnums:      1,
 			NumMessages:   3,
 			NumExtensions: 0,
 			NumServices:   1,
 		},
-		GoTypes:           file_status_proto_goTypes,
-		DependencyIndexes: file_status_proto_depIdxs,
-		EnumInfos:         file_status_proto_enumTypes,
-		MessageInfos:      file_status_proto_msgTypes,
+		GoTypes:           file_anovel_jsonkeys_v2_status_proto_goTypes,
+		DependencyIndexes: file_anovel_jsonkeys_v2_status_proto_depIdxs,
+		EnumInfos:         file_anovel_jsonkeys_v2_status_proto_enumTypes,
+		MessageInfos:      file_anovel_jsonkeys_v2_status_proto_msgTypes,
 	}.Build()
-	File_status_proto = out.File
-	file_status_proto_goTypes = nil
-	file_status_proto_depIdxs = nil
+	File_anovel_jsonkeys_v2_status_proto = out.File
+	file_anovel_jsonkeys_v2_status_proto_goTypes = nil
+	file_anovel_jsonkeys_v2_status_proto_depIdxs = nil
 }

--- a/internal/handlers/protogen/anovel/jsonkeys/v2/status_grpc.pb.go
+++ b/internal/handlers/protogen/anovel/jsonkeys/v2/status_grpc.pb.go
@@ -2,9 +2,9 @@
 // versions:
 // - protoc-gen-go-grpc v1.6.2
 // - protoc             (unknown)
-// source: status.proto
+// source: anovel/jsonkeys/v2/status.proto
 
-package protogen
+package jsonkeysv2
 
 import (
 	context "context"
@@ -19,7 +19,7 @@ import (
 const _ = grpc.SupportPackageIsVersion9
 
 const (
-	StatusService_Status_FullMethodName = "/StatusService/Status"
+	StatusService_Status_FullMethodName = "/anovel.jsonkeys.v2.StatusService/Status"
 )
 
 // StatusServiceClient is the client API for StatusService service.
@@ -114,7 +114,7 @@ func _StatusService_Status_Handler(srv interface{}, ctx context.Context, dec fun
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
 var StatusService_ServiceDesc = grpc.ServiceDesc{
-	ServiceName: "StatusService",
+	ServiceName: "anovel.jsonkeys.v2.StatusService",
 	HandlerType: (*StatusServiceServer)(nil),
 	Methods: []grpc.MethodDesc{
 		{
@@ -123,5 +123,5 @@ var StatusService_ServiceDesc = grpc.ServiceDesc{
 		},
 	},
 	Streams:  []grpc.StreamDesc{},
-	Metadata: "status.proto",
+	Metadata: "anovel/jsonkeys/v2/status.proto",
 }

--- a/internal/handlers/rest.health.go
+++ b/internal/handlers/rest.health.go
@@ -20,7 +20,7 @@ const (
 )
 
 // RestHealthStatus is the JSON representation of a single dependency's health.
-// /healthcheck is public and unauthenticated, so the body carries the status alone:
+// /v2/healthcheck is public and unauthenticated, so the body carries the status alone:
 // raw error messages embed internal hostnames, ports and schema names. The underlying
 // error is recorded on the trace span for operators.
 type RestHealthStatus struct {

--- a/internal/handlers/rest.health_test.go
+++ b/internal/handlers/rest.health_test.go
@@ -32,7 +32,7 @@ func TestRestHealth(t *testing.T) {
 		{
 			name: "Success",
 
-			request: httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/healthcheck", nil),
+			request: httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/v2/healthcheck", nil),
 
 			expectResponse: map[string]any{
 				"client:postgres": map[string]any{
@@ -48,7 +48,7 @@ func TestRestHealth(t *testing.T) {
 			// re-introduced "err") leaks into the public response shape.
 			name: "Success/Degraded",
 
-			request: httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/healthcheck", nil),
+			request: httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/v2/healthcheck", nil),
 
 			skipPostgres: true,
 

--- a/internal/handlers/rest.jwkGet_test.go
+++ b/internal/handlers/rest.jwkGet_test.go
@@ -46,7 +46,7 @@ func TestRestJwkGet(t *testing.T) {
 			request: httptest.NewRequestWithContext(
 				t.Context(),
 				http.MethodGet,
-				"/jwk?id=00000000-0000-0000-0000-000000000001",
+				"/v2/jwk?id=00000000-0000-0000-0000-000000000001",
 				nil,
 			),
 
@@ -79,7 +79,7 @@ func TestRestJwkGet(t *testing.T) {
 			request: httptest.NewRequestWithContext(
 				t.Context(),
 				http.MethodGet,
-				"/jwk?id=not-a-uuid",
+				"/v2/jwk?id=not-a-uuid",
 				nil,
 			),
 
@@ -91,7 +91,7 @@ func TestRestJwkGet(t *testing.T) {
 			request: httptest.NewRequestWithContext(
 				t.Context(),
 				http.MethodGet,
-				"/jwk?id=00000000-0000-0000-0000-000000000001",
+				"/v2/jwk?id=00000000-0000-0000-0000-000000000001",
 				nil,
 			),
 
@@ -107,7 +107,7 @@ func TestRestJwkGet(t *testing.T) {
 			request: httptest.NewRequestWithContext(
 				t.Context(),
 				http.MethodGet,
-				"/jwk?id=00000000-0000-0000-0000-000000000001",
+				"/v2/jwk?id=00000000-0000-0000-0000-000000000001",
 				nil,
 			),
 

--- a/internal/handlers/rest.jwkList_test.go
+++ b/internal/handlers/rest.jwkList_test.go
@@ -42,7 +42,7 @@ func TestRestJwkList(t *testing.T) {
 		{
 			name: "Success",
 
-			request: httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/jwks?usage=test-usage", nil),
+			request: httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/v2/jwks?usage=test-usage", nil),
 
 			serviceMock: &serviceMock{
 				resp: []*core.Jwk{
@@ -74,7 +74,7 @@ func TestRestJwkList(t *testing.T) {
 		{
 			name: "Success/Empty",
 
-			request: httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/jwks?usage=test-usage", nil),
+			request: httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/v2/jwks?usage=test-usage", nil),
 
 			serviceMock: &serviceMock{
 				resp: []*core.Jwk{},
@@ -86,7 +86,7 @@ func TestRestJwkList(t *testing.T) {
 		{
 			name: "Error/Internal",
 
-			request: httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/jwks?usage=test-usage", nil),
+			request: httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/v2/jwks?usage=test-usage", nil),
 
 			serviceMock: &serviceMock{
 				err: errFoo,

--- a/internal/handlers/rest.ping_test.go
+++ b/internal/handlers/rest.ping_test.go
@@ -35,7 +35,7 @@ func TestRestPing(t *testing.T) {
 			handler := handlers.NewRestPing()
 			w := httptest.NewRecorder()
 
-			handler.ServeHTTP(w, httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/ping", nil))
+			handler.ServeHTTP(w, httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/v2/ping", nil))
 
 			res := w.Result()
 			require.Equal(t, testCase.expectStatus, res.StatusCode)

--- a/internal/models/proto/anovel/jsonkeys/v2/claims_sign.proto
+++ b/internal/models/proto/anovel/jsonkeys/v2/claims_sign.proto
@@ -1,5 +1,7 @@
 syntax = "proto3";
 
+package anovel.jsonkeys.v2;
+
 import "google/protobuf/any.proto";
 
 // ClaimsSignService remotely generates a signed token from claims. The parameters used to

--- a/internal/models/proto/anovel/jsonkeys/v2/jwk.proto
+++ b/internal/models/proto/anovel/jsonkeys/v2/jwk.proto
@@ -1,5 +1,7 @@
 syntax = "proto3";
 
+package anovel.jsonkeys.v2;
+
 // Jwk represents a public JSON Web Key. Private key material is never included.
 message Jwk {
   // Key type identifier. Corresponds to the "kty" JWK parameter (RFC 7517 §4.1).

--- a/internal/models/proto/anovel/jsonkeys/v2/jwk_get.proto
+++ b/internal/models/proto/anovel/jsonkeys/v2/jwk_get.proto
@@ -1,6 +1,8 @@
 syntax = "proto3";
 
-import "jwk.proto";
+package anovel.jsonkeys.v2;
+
+import "anovel/jsonkeys/v2/jwk.proto";
 
 // JwkGetService returns a public JSON Web Key by its key ID.
 // The returned key may be used by any recipient to verify a token.

--- a/internal/models/proto/anovel/jsonkeys/v2/jwk_list.proto
+++ b/internal/models/proto/anovel/jsonkeys/v2/jwk_list.proto
@@ -1,6 +1,8 @@
 syntax = "proto3";
 
-import "jwk.proto";
+package anovel.jsonkeys.v2;
+
+import "anovel/jsonkeys/v2/jwk.proto";
 
 // JwkListService lists the active public keys for a given usage.
 service JwkListService {

--- a/internal/models/proto/anovel/jsonkeys/v2/status.proto
+++ b/internal/models/proto/anovel/jsonkeys/v2/status.proto
@@ -1,5 +1,7 @@
 syntax = "proto3";
 
+package anovel.jsonkeys.v2;
+
 // StatusService returns the health of the gRPC server dependencies.
 service StatusService {
   // Returns the current health of all server dependencies checked at request time.

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -30,14 +30,14 @@ tags:
     description: Endpoints for retrieving public JSON Web Keys used to verify signed tokens.
 
 paths:
-  /ping:
+  /v2/ping:
     get:
       operationId: ping
       summary: Ping the server.
       description: |
         A simple endpoint to check if the server is up and running. It always returns the same response.
 
-        This does not report on the server's dependencies; use the `/healthcheck` endpoint for that.
+        This does not report on the server's dependencies; use the `/v2/healthcheck` endpoint for that.
       tags: [health]
       security: []
       responses:
@@ -46,7 +46,7 @@ paths:
         default:
           $ref: "#/components/responses/internalError"
 
-  /healthcheck:
+  /v2/healthcheck:
     get:
       operationId: healthcheck
       summary: Health diagnosis of the server.
@@ -60,7 +60,7 @@ paths:
         default:
           $ref: "#/components/responses/internalError"
 
-  /jwks:
+  /v2/jwks:
     get:
       operationId: jwkList
       summary: List public JSON Web Keys.
@@ -77,7 +77,7 @@ paths:
         default:
           $ref: "#/components/responses/internalError"
 
-  /jwk:
+  /v2/jwk:
     get:
       operationId: jwkGet
       summary: Get a public JSON Web Key by ID.

--- a/pkg/go/client.go
+++ b/pkg/go/client.go
@@ -9,18 +9,18 @@ import (
 	golibproto "github.com/a-novel-kit/golib/grpcf/proto/gen"
 
 	"github.com/a-novel/service-json-keys/v2/internal/config"
-	"github.com/a-novel/service-json-keys/v2/internal/handlers/protogen"
+	jsonkeysv2 "github.com/a-novel/service-json-keys/v2/internal/handlers/protogen/anovel/jsonkeys/v2"
 )
 
 type (
-	StatusRequest      = protogen.StatusRequest
-	StatusResponse     = protogen.StatusResponse
-	JwkListRequest     = protogen.JwkListRequest
-	JwkListResponse    = protogen.JwkListResponse
-	JwkGetRequest      = protogen.JwkGetRequest
-	JwkGetResponse     = protogen.JwkGetResponse
-	ClaimsSignRequest  = protogen.ClaimsSignRequest
-	ClaimsSignResponse = protogen.ClaimsSignResponse
+	StatusRequest      = jsonkeysv2.StatusRequest
+	StatusResponse     = jsonkeysv2.StatusResponse
+	JwkListRequest     = jsonkeysv2.JwkListRequest
+	JwkListResponse    = jsonkeysv2.JwkListResponse
+	JwkGetRequest      = jsonkeysv2.JwkGetRequest
+	JwkGetResponse     = jsonkeysv2.JwkGetResponse
+	ClaimsSignRequest  = jsonkeysv2.ClaimsSignRequest
+	ClaimsSignResponse = jsonkeysv2.ClaimsSignResponse
 
 	// JwkConfig holds the full configuration for a single key usage — the signing algorithm
 	// and the key and token parameters applied to every JWT signed under it.
@@ -72,10 +72,10 @@ type Client interface {
 
 type client struct {
 	golibproto.EchoServiceClient
-	protogen.StatusServiceClient
-	protogen.JwkGetServiceClient
-	protogen.JwkListServiceClient
-	protogen.ClaimsSignServiceClient
+	jsonkeysv2.StatusServiceClient
+	jsonkeysv2.JwkGetServiceClient
+	jsonkeysv2.JwkListServiceClient
+	jsonkeysv2.ClaimsSignServiceClient
 
 	keys map[string]*JwkConfig
 
@@ -101,10 +101,10 @@ func NewClient(addr string, opts ...grpc.DialOption) (Client, error) {
 
 	c := &client{
 		EchoServiceClient:       golibproto.NewEchoServiceClient(conn),
-		StatusServiceClient:     protogen.NewStatusServiceClient(conn),
-		JwkGetServiceClient:     protogen.NewJwkGetServiceClient(conn),
-		JwkListServiceClient:    protogen.NewJwkListServiceClient(conn),
-		ClaimsSignServiceClient: protogen.NewClaimsSignServiceClient(conn),
+		StatusServiceClient:     jsonkeysv2.NewStatusServiceClient(conn),
+		JwkGetServiceClient:     jsonkeysv2.NewJwkGetServiceClient(conn),
+		JwkListServiceClient:    jsonkeysv2.NewJwkListServiceClient(conn),
+		ClaimsSignServiceClient: jsonkeysv2.NewClaimsSignServiceClient(conn),
 		keys:                    config.JwkPresetDefault,
 		conn:                    conn,
 	}

--- a/pkg/go/jwkExportGrpc.go
+++ b/pkg/go/jwkExportGrpc.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/a-novel-kit/jwt/v2/jwa"
 
-	"github.com/a-novel/service-json-keys/v2/internal/handlers/protogen"
+	jsonkeysv2 "github.com/a-novel/service-json-keys/v2/internal/handlers/protogen/anovel/jsonkeys/v2"
 )
 
 // A jwkExportGrpc adapts a [BaseClient] to the key-source fetch interface used when initializing
@@ -26,7 +26,7 @@ func (api *jwkExportGrpc) SearchKeys(ctx context.Context, usage string) ([]*jwa.
 		return nil, err
 	}
 
-	keys := lo.Map(res.GetKeys(), func(item *protogen.Jwk, index int) *jwa.JWK {
+	keys := lo.Map(res.GetKeys(), func(item *jsonkeysv2.Jwk, index int) *jwa.JWK {
 		return &jwa.JWK{
 			JWKCommon: jwa.JWKCommon{
 				KTY: jwa.KTY(item.GetKty()),

--- a/pkg/js/rest/src/api.ts
+++ b/pkg/js/rest/src/api.ts
@@ -8,7 +8,7 @@ async function decodeRawHttpResponse<T>(response: Response): Promise<T> {
   return await response.json();
 }
 
-/** Status of a single health-check dependency reported by the `/healthcheck` endpoint. */
+/** Status of a single health-check dependency reported by the `/v2/healthcheck` endpoint. */
 export type HealthDependency = {
   /** Whether the dependency is reachable. */
   status: "up" | "down";
@@ -50,7 +50,7 @@ export class JsonKeysApi {
 
   /** Checks that the server is reachable. Throws on any non-2xx response. */
   async ping(): Promise<void> {
-    await this.fetchVoid("/ping", { method: "GET" });
+    await this.fetchVoid("/v2/ping", { method: "GET" });
   }
 
   /**
@@ -59,6 +59,6 @@ export class JsonKeysApi {
    * so inspect each entry's `status` field to detect one.
    */
   async health(): Promise<Record<string, HealthDependency>> {
-    return await this.fetch("/healthcheck", undefined, { method: "GET" });
+    return await this.fetch("/v2/healthcheck", undefined, { method: "GET" });
   }
 }

--- a/pkg/js/rest/src/jwk.ts
+++ b/pkg/js/rest/src/jwk.ts
@@ -58,7 +58,7 @@ export async function jwkList(api: JsonKeysApi, usage?: string): Promise<Jwk[]> 
   const params = new URLSearchParams();
   if (usage) params.set("usage", usage);
   const query = params.toString();
-  return await api.fetch(`/jwks${query ? `?${query}` : ""}`, z.array(JwkSchema), {
+  return await api.fetch(`/v2/jwks${query ? `?${query}` : ""}`, z.array(JwkSchema), {
     method: "GET",
     headers: HTTP_HEADERS.JSON,
   });
@@ -76,5 +76,5 @@ export async function jwkList(api: JsonKeysApi, usage?: string): Promise<Jwk[]> 
 export async function jwkGet(api: JsonKeysApi, id: string): Promise<Jwk> {
   const params = new URLSearchParams();
   params.set("id", id);
-  return await api.fetch(`/jwk?${params.toString()}`, JwkSchema, { method: "GET", headers: HTTP_HEADERS.JSON });
+  return await api.fetch(`/v2/jwk?${params.toString()}`, JwkSchema, { method: "GET", headers: HTTP_HEADERS.JSON });
 }

--- a/redocly.yaml
+++ b/redocly.yaml
@@ -1,9 +1,9 @@
 extends: [recommended]
 
 rules:
-  # /ping, /healthcheck, and /jwks intentionally have no 4xx responses:
-  # - /ping and /healthcheck accept no input, so 400 is unreachable.
-  # - /jwks accepts any string for `usage` and returns an empty list for unrecognized
+  # /v2/ping, /v2/healthcheck, and /v2/jwks intentionally have no 4xx responses:
+  # - /v2/ping and /v2/healthcheck accept no input, so 400 is unreachable.
+  # - /v2/jwks accepts any string for `usage` and returns an empty list for unrecognized
   #   values rather than a 400, so 400 is also unreachable there.
-  # /jwk does have explicit 400/404 responses and is unaffected by this override.
+  # /v2/jwk does have explicit 400/404 responses and is unaffected by this override.
   operation-4xx-response: off


### PR DESCRIPTION
## Summary

- move the five protobuf contracts beneath `anovel/jsonkeys/v2` and publish gRPC methods as `/anovel.jsonkeys.v2.<Service>/<Method>`
- mount the complete REST API under `/v2`, including ping and healthcheck
- update generated bindings, handlers, Go/JS clients, tests, OpenAPI, contributor examples, and container health probes
- preserve the exported `pkg/go` API names while deliberately changing the wire contract

## Breaking changes and migration

There are no compatibility aliases.

- gRPC callers must use `/anovel.jsonkeys.v2.<Service>/<Method>` and regenerate from `internal/models/proto/anovel/jsonkeys/v2` when consuming descriptors directly.
- REST callers must prefix every route with `/v2`: `/v2/ping`, `/v2/healthcheck`, `/v2/jwks`, and `/v2/jwk`.
- The in-repository Go and JS clients already target the new routes.

## Baseline and landing order

Buf remains on strict `FILE` comparison with no `ignore_only`. This PR intentionally reports exactly the five deleted unversioned descriptors and must be force-landed once as the new baseline.

After landing, release `service-json-keys@v2.5.0`. `service-authentication` must then re-pin both its Go client and integration image before its corresponding contract PR can merge.

## Verification

- [x] `pnpm format`
- [x] `pnpm lint:proto`
- [x] `pnpm lint:go`
- [x] `pnpm lint:js` (including Redocly)
- [x] `a-novel test --type=go -y`
- [x] `a-novel test --type=pnpm -y`
- [x] `a-novel build --type=go,pnpm -y`
- [x] `a-novel build --type=podman -y` (all seven images)
- [x] repeated `go generate .` output is stable
- [x] Buf breaking output contains only the five expected old descriptor deletions

CI is expected to be green except for the intentional one-time `lint-proto` baseline failure described above.

Closes #901